### PR TITLE
Implement black mode and remove intros

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1,6 +1,7 @@
 body {
   margin: 0;
-  background: #fff;
+  background: linear-gradient(to top, #ff0000 0%, #fff 50%, #fff 100%);
+  transition: background 1s linear;
   font-family: 'Open Sans', sans-serif;
 }
 


### PR DESCRIPTION
## Summary
- remove all intro screens for game modes and level transitions
- add dynamic gradient background tied to progress bar color
- support voice commands 'black mode' and 'versão escura' to toggle dark background
- update styles to animate background color changes

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688b841516648325aa5d80ef669d1b20