### PR TITLE
Implement level icon and restart hotkey

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -109,16 +109,13 @@ body {
 
 #nivel-indicador {
   position: absolute;
-  top: 30px;
-  left: 50%;
-  transform: translateX(-50%);
-  padding: 5px 10px;
-  font-size: 24px;
-  font-family: 'Open Sans', sans-serif;
-  color: #333;
-  font-weight: normal;
+  top: 100px;
+  left: 100px;
+  width: 75px;
+  height: 75px;
+  object-fit: contain;
   user-select: none;
-  text-align: center;
+  pointer-events: none;
 }
 
 

--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@
 
   <div id="visor">
     <!-- conteúdo visual aqui -->
-    <div id="nivel-indicador"></div>
+    <img id="nivel-indicador" alt="Level" />
     <div id="score"></div>
     <div id="texto-exibicao"></div>
     <div id="pt-container">

--- a/js/main.js
+++ b/js/main.js
@@ -170,6 +170,14 @@ const modeIntros = {
   6: { duration: 6000, img: modeImages[6], audio: 'somModo6Intro' }
 };
 
+function updateLevelIcon() {
+  const icon = document.getElementById('nivel-indicador');
+  if (icon) {
+    icon.src = `selos_niveis/level%20${pastaAtual}.png`;
+  }
+  localStorage.setItem('pastaAtual', pastaAtual);
+}
+
 const levelUpTransition = {
   duration: 4000,
   img: 'https://cdn.dribbble.com/userupload/41814123/file/original-fb8a772ba8676fd28c528fd1259cabcb.gif',
@@ -421,7 +429,7 @@ function beginGame() {
       icon.src = modeImages[selectedMode];
       icon.style.display = 'block';
     }
-    document.getElementById('nivel-indicador').innerText = `Level ${pastaAtual}`;
+    updateLevelIcon();
     switch (selectedMode) {
       case 1:
         mostrarTexto = 'pt';
@@ -606,7 +614,7 @@ function verificarResposta() {
     const nivel = parseInt(cheat[1], 10);
     if (pastas[nivel]) {
       pastaAtual = nivel;
-      document.getElementById("nivel-indicador").innerText = `Level ${pastaAtual}`;
+      updateLevelIcon();
       carregarFrases();
     }
     input.value = "";
@@ -749,6 +757,7 @@ function nextLevel() {
       selectedMode = 1;
       pastaAtual++;
     }
+    updateLevelIcon();
     beginGame();
   };
 
@@ -775,8 +784,10 @@ function goHome() {
 
 
 window.onload = async () => {
+  const saved = parseInt(localStorage.getItem('pastaAtual'), 10);
+  if (saved) pastaAtual = saved;
   await carregarPastas();
-  document.getElementById("nivel-indicador").innerText = `Level ${pastaAtual}`;
+  updateLevelIcon();
 
   if (reconhecimento) {
     reconhecimento.lang = 'en-US';
@@ -798,5 +809,17 @@ window.onload = async () => {
   document.addEventListener('keydown', e => {
     if (e.key === 'r') falarFrase();
     if (e.key === 'h') goHome();
+    if (e.key.toLowerCase() === 'l') {
+      if (reconhecimento) {
+        reconhecimentoAtivo = false;
+        reconhecimento.stop();
+      }
+      clearInterval(timerInterval);
+      clearInterval(prizeTimer);
+      pastaAtual++;
+      points = 3500;
+      updateLevelIcon();
+      beginGame();
+    }
   });
 };


### PR DESCRIPTION
## Summary
- show level as an icon instead of text
- save and load level from localStorage
- add `L` key shortcut to restart current mode on the next level

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688bc4ba165883259eb807a287be53cc