### PR TITLE
Add mode selector and auto mode progression

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -11,7 +11,7 @@ body {
   justify-content: center;
   gap: 20px;
   height: 100vh;
-  padding: 0 5vw 100px 5vw;
+  padding: 0 5vw 200px 5vw;
   display: none;
 }
 
@@ -179,6 +179,25 @@ body {
   height: 100px;
   opacity: 0.8;
   pointer-events: none;
+}
+
+#mode-buttons {
+  position: fixed;
+  bottom: 10px;
+  left: 0;
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  gap: 10px;
+  z-index: 999;
+}
+
+#mode-buttons img {
+  width: 60px;
+  height: 60px;
+  cursor: pointer;
+  opacity: 0.35;
+  transition: opacity 0.2s linear;
 }
 
 @media (max-width: 600px) {

--- a/index.html
+++ b/index.html
@@ -29,6 +29,14 @@
     <div id="resultado"></div>
     <div id="acertos"></div>
     <img id="mode-icon" alt="Mode Icon" style="display:none" />
+    <div id="mode-buttons">
+      <img src="selos%20modos%20de%20jogo/modo1.png" data-mode="1" class="mode-btn" alt="Modo 1" />
+      <img src="selos%20modos%20de%20jogo/modo2.png" data-mode="2" class="mode-btn" alt="Modo 2" />
+      <img src="selos%20modos%20de%20jogo/modo3.png" data-mode="3" class="mode-btn" alt="Modo 3" />
+      <img src="selos%20modos%20de%20jogo/modo4.png" data-mode="4" class="mode-btn" alt="Modo 4" />
+      <img src="selos%20modos%20de%20jogo/modo5.png" data-mode="5" class="mode-btn" alt="Modo 5" />
+      <img src="selos%20modos%20de%20jogo/modo6.png" data-mode="6" class="mode-btn" alt="Modo 6" />
+    </div>
   </div>
 
   <div id="intro-overlay" style="display:none">

--- a/js/main.js
+++ b/js/main.js
@@ -178,6 +178,15 @@ function updateLevelIcon() {
   localStorage.setItem('pastaAtual', pastaAtual);
 }
 
+function updateModeIcons() {
+  document.querySelectorAll('#mode-buttons img').forEach(img => {
+    const mode = parseInt(img.dataset.mode, 10);
+    img.style.opacity = mode === selectedMode ? '1' : '0.35';
+  });
+}
+
+let transitioning = false;
+
 const levelUpTransition = {
   duration: 4000,
   img: 'https://cdn.dribbble.com/userupload/41814123/file/original-fb8a772ba8676fd28c528fd1259cabcb.gif',
@@ -278,6 +287,7 @@ function stopTryAgainAnimation() {
 
 function startGame(modo) {
   selectedMode = modo;
+  updateModeIcons();
   listeningForCommand = false;
   document.getElementById('menu').style.display = 'none';
   document.getElementById('visor').style.display = 'none';
@@ -430,6 +440,7 @@ function beginGame() {
       icon.style.display = 'block';
     }
     updateLevelIcon();
+    updateModeIcons();
     switch (selectedMode) {
       case 1:
         mostrarTexto = 'pt';
@@ -691,6 +702,9 @@ function atualizarBarraProgresso() {
   if (points <= 0) {
     showTryAgain();
   }
+  if (points >= 24999) {
+    nextMode();
+  }
 }
 
 function showTryAgain() {
@@ -739,6 +753,35 @@ function showTryAgain() {
   }
 }
 
+function nextMode() {
+  if (transitioning) return;
+  transitioning = true;
+  if (selectedMode < 6) {
+    const current = selectedMode;
+    const next = current + 1;
+    const info = modeTransitions[current];
+    selectedMode = next;
+    const done = () => {
+      startGame(next);
+      transitioning = false;
+    };
+    if (info) {
+      showModeTransition(info, done);
+    } else {
+      done();
+    }
+  } else {
+    pastaAtual++;
+    selectedMode = 1;
+    const done = () => {
+      updateLevelIcon();
+      startGame(1);
+      transitioning = false;
+    };
+    showModeTransition(levelUpTransition, done);
+  }
+}
+
 
 function goHome() {
   document.getElementById('visor').style.display = 'none';
@@ -759,6 +802,14 @@ window.onload = async () => {
   if (saved) pastaAtual = saved;
   await carregarPastas();
   updateLevelIcon();
+  updateModeIcons();
+
+  document.querySelectorAll('#mode-buttons img').forEach(img => {
+    img.addEventListener('click', () => {
+      const modo = parseInt(img.dataset.mode, 10);
+      startGame(modo);
+    });
+  });
 
   if (reconhecimento) {
     reconhecimento.lang = 'en-US';


### PR DESCRIPTION
## Summary
- shift game content up and add fixed row of mode icons
- highlight current mode icon and switch modes when clicking
- automatically progress to the next mode at 24,999 points

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688bcd27be088325a52b0605cad0f5b8