### PR TITLE
Ensure level reset at 24999 points

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -687,6 +687,9 @@ function verificarResposta() {
 }
 
 function continuar() {
+  if (points >= 24999 || transitioning) {
+    return;
+  }
   fraseIndex++;
   mostrarFrase();
 }
@@ -831,6 +834,13 @@ window.onload = async () => {
   document.addEventListener('keydown', e => {
     if (e.key === 'r') falarFrase();
     if (e.key === 'h') goHome();
+    if (e.key.toLowerCase() === 'i') {
+      const [pt, en] = frasesArr[fraseIndex] || ['',''];
+      const esperado = esperadoLang === 'pt' ? pt : en;
+      document.getElementById('pt').value = esperado;
+      verificarResposta();
+      return;
+    }
     if (e.key.toLowerCase() === 'l') {
       if (reconhecimento) {
         reconhecimentoAtivo = false;


### PR DESCRIPTION
## Summary
- don't show a new phrase once score reaches 24999
- allow pressing `i` to count as a correct answer

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_688bd92d12c88325bca7ba865a00a854