### PR TITLE
Implement dark mode and update scoring

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -4,6 +4,25 @@ body {
   font-family: 'Open Sans', sans-serif;
 }
 
+body.dark-mode {
+  background: #000;
+  color: #fff;
+}
+
+body.dark-mode #pt,
+body.dark-mode #texto-exibicao,
+body.dark-mode #resultado,
+body.dark-mode #acertos,
+body.dark-mode #nivel-mensagem,
+body.dark-mode #timer {
+  color: #fff;
+  caret-color: #fff;
+}
+
+body.dark-mode #intro-overlay {
+  background: #000;
+}
+
 #visor {
   display: flex;
   flex-direction: column;

--- a/js/main.js
+++ b/js/main.js
@@ -313,6 +313,8 @@ function showMode1Intro(callback) {
   const overlay = document.getElementById('intro-overlay');
   const audio = document.getElementById('somModo1Intro');
   const img = document.getElementById('intro-image');
+  points = 3500;
+  atualizarBarraProgresso();
   img.style.animation = 'none';
   img.style.transition = 'none';
   img.style.opacity = '1';
@@ -342,6 +344,8 @@ function showModeIntro(info, callback) {
   const overlay = document.getElementById('intro-overlay');
   const img = document.getElementById('intro-image');
   const audio = document.getElementById(info.audio);
+  points = 3500;
+  atualizarBarraProgresso();
   img.src = info.img;
   img.style.animation = 'none';
   img.style.transition = 'none';
@@ -374,6 +378,8 @@ function showModeTransition(info, callback) {
   const overlay = document.getElementById('intro-overlay');
   const img = document.getElementById('intro-image');
   const audio = document.getElementById(info.audio);
+  points = 3500;
+  atualizarBarraProgresso();
   img.src = info.img;
   img.style.animation = 'none';
   img.style.transition = 'none';
@@ -406,6 +412,8 @@ function showLevelUp(callback) {
   const overlay = document.getElementById('intro-overlay');
   const img = document.getElementById('intro-image');
   const audio = document.getElementById(levelUpTransition.audio);
+  points = 3500;
+  atualizarBarraProgresso();
   img.src = levelUpTransition.img;
   img.style.animation = 'none';
   img.style.width = '397px';
@@ -507,6 +515,10 @@ function togglePt() {
 function toggleEn() {
   voz = voz ? null : 'en';
   mostrarFrase();
+}
+
+function toggleDarkMode() {
+  document.body.classList.toggle('dark-mode');
 }
 
 function falarFrase() {
@@ -687,7 +699,7 @@ function verificarResposta() {
 }
 
 function continuar() {
-  if (points >= 24999 || transitioning) {
+  if (points > 24998 || transitioning) {
     return;
   }
   fraseIndex++;
@@ -705,7 +717,7 @@ function atualizarBarraProgresso() {
   if (points <= 0) {
     showTryAgain();
   }
-  if (points >= 24999) {
+  if (points > 24998) {
     nextMode();
   }
 }
@@ -833,7 +845,7 @@ window.onload = async () => {
 
   document.addEventListener('keydown', e => {
     if (e.key === 'r') falarFrase();
-    if (e.key === 'h') goHome();
+    if (e.key.toLowerCase() === 'h') toggleDarkMode();
     if (e.key.toLowerCase() === 'i') {
       const [pt, en] = frasesArr[fraseIndex] || ['',''];
       const esperado = esperadoLang === 'pt' ? pt : en;


### PR DESCRIPTION
## Summary
- support dark mode via `H` key
- reset points to 3500 when showing mode intros and transitions
- trigger next mode when points exceed 24,998

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688bdd80cafc83258248c6a9e035d8bf