### PR TITLE
Fix intro loop when leveling up

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -382,6 +382,10 @@ function showModeTransition(info, callback) {
   const audio = document.getElementById(info.audio);
   points = INITIAL_POINTS;
   atualizarBarraProgresso();
+  if (reconhecimento) {
+    reconhecimentoAtivo = false;
+    reconhecimento.stop();
+  }
   img.src = info.img;
   img.style.animation = 'none';
   img.style.transition = 'none';


### PR DESCRIPTION
## Summary
- stop speech recognition when running mode transitions to prevent intro audio from triggering additional `nextMode()` calls

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688bf1e7a97083259f80d5a251754718