### PR TITLE
Implement new menu and scoring logic

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -36,23 +36,39 @@ body.dark-mode #intro-overlay {
 
 #menu {
   display: flex;
-  flex-wrap: wrap;
-  justify-content: center;
+  flex-direction: column;
   align-items: center;
-  gap: 20px;
+  justify-content: center;
+  gap: 40px;
   height: 100vh;
 }
 
-#menu button {
-  background: none;
-  border: none;
-  cursor: pointer;
+#clock {
+  font-size: clamp(40px, 8vw, 80px);
+  font-family: 'Open Sans', sans-serif;
+  font-weight: normal;
+  color: #000;
+  text-align: center;
 }
 
-#menu img {
-  width: 50%;
-  max-width: 400px;
-  height: auto;
+body.dark-mode #clock {
+  color: #fff;
+}
+
+#menu-modes {
+  display: grid;
+  grid-template-columns: repeat(3, 175px);
+  grid-auto-rows: 175px;
+  gap: 50px;
+}
+
+#menu-modes img {
+  width: 175px;
+  height: 175px;
+  object-fit: contain;
+  cursor: pointer;
+  opacity: 0.3;
+  transition: opacity 0.2s linear;
 }
 
 
@@ -223,6 +239,20 @@ body.dark-mode #intro-overlay {
   #mode-icon {
     width: 40px;
     height: 40px;
+  }
+
+  #clock {
+    font-size: 12vw;
+  }
+
+  #menu-modes {
+    grid-template-columns: repeat(3, 1fr);
+    gap: 20px;
+  }
+
+  #menu-modes img {
+    width: 28vw;
+    height: 28vw;
   }
 }
 

--- a/index.html
+++ b/index.html
@@ -9,7 +9,15 @@
 </head>
 <body>
   <div id="menu">
-    <img id="start-image" src="https://i.pinimg.com/originals/70/b4/66/70b46663202c4db0b820cf3db4f57837.gif" alt="Iniciar">
+    <div id="clock"></div>
+    <div id="menu-modes">
+      <img src="selos%20modos%20de%20jogo/modo1.png" data-mode="1" alt="Modo 1">
+      <img src="selos%20modos%20de%20jogo/modo2.png" data-mode="2" alt="Modo 2">
+      <img src="selos%20modos%20de%20jogo/modo3.png" data-mode="3" alt="Modo 3">
+      <img src="selos%20modos%20de%20jogo/modo4.png" data-mode="4" alt="Modo 4">
+      <img src="selos%20modos%20de%20jogo/modo5.png" data-mode="5" alt="Modo 5">
+      <img src="selos%20modos%20de%20jogo/modo6.png" data-mode="6" alt="Modo 6">
+    </div>
   </div>
 
 


### PR DESCRIPTION
## Summary
- add main menu with clock and mode buttons
- style menu and make responsive
- track completed modes and update icons
- adjust scoring rules and remove game over state
- display Brasilia time during menu

## Testing
- `node -c js/main.js`

------
https://chatgpt.com/codex/tasks/task_e_688c3121eb788325b0fc5f30ddec2da2