### PR TITLE
Implement tutorial intro and unlock audio

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -265,3 +265,25 @@ body.dark-mode #clock {
   from { transform: scale(0.8); }
   to { transform: scale(1); }
 }
+
+#logo-top {
+  position: absolute;
+  top: 20px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 100px;
+  height: auto;
+  z-index: 1000;
+  display: none;
+}
+
+#tutorial-logo {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 20vw;
+  height: auto;
+  z-index: 10000;
+  display: none;
+}

--- a/index.html
+++ b/index.html
@@ -9,6 +9,8 @@
 </head>
 <body>
   <img id="nivel-indicador" alt="Level" />
+  <img id="logo-top" src="logoitalk.png" alt="Logo Italk" style="display:none" />
+  <img id="tutorial-logo" src="logoitalk.png" alt="Logo Italk" style="display:none" />
   <div id="menu">
     <div id="clock"></div>
     <div id="menu-modes">
@@ -62,6 +64,10 @@
   <audio id="somModo6Intro" src="gamesounds/mode6first.mp3"></audio>
   <audio id="somNextLevel" src="gamesounds/nextlevel.mp3"></audio>
   <audio id="somLetsPlay" src="gamesounds/letsplay.mp3"></audio>
+
+  <audio id="somWelcome" src="gamesounds/welcome.mp3"></audio>
+  <audio id="somModoDesbloqueado" src="gamesounds/mododesbloqueado.mp3"></audio>
+  <audio id="somNivelDesbloqueado" src="gamesounds/niveldesbloqueado.mp3"></audio>
 
   <audio id="somAcerto" src="gamesounds/success.mp3"></audio>
   <audio id="somErro" src="gamesounds/error.mp3"></audio>

--- a/js/main.js
+++ b/js/main.js
@@ -200,7 +200,7 @@ function checkForMenuLevelUp() {
   const allComplete = [1,2,3,4,5,6].every(m => completedModes[m]);
   if (allComplete && !levelUpReady) {
     levelUpReady = true;
-    const audio = document.getElementById('somNextLevel');
+    const audio = document.getElementById('somNivelDesbloqueado');
     if (audio) { audio.currentTime = 0; audio.play(); }
     awaitingNextLevel = true;
     nextLevelCallback = performMenuLevelUp;
@@ -765,9 +765,21 @@ function atualizarBarraProgresso() {
   filled.style.width = perc + '%';
   filled.style.backgroundColor = calcularCor(points);
   if (points >= COMPLETION_THRESHOLD && !completedModes[selectedMode]) {
-    completedModes[selectedMode] = true;
-    localStorage.setItem('completedModes', JSON.stringify(completedModes));
-    updateModeIcons();
+    const unlocked = Object.values(completedModes).filter(Boolean).length;
+    if (unlocked >= 5) {
+      const audio = document.getElementById('somNivelDesbloqueado');
+      if (audio) { audio.currentTime = 0; audio.play(); }
+      completedModes[selectedMode] = true;
+      localStorage.setItem('completedModes', JSON.stringify(completedModes));
+      updateModeIcons();
+      goHome();
+    } else {
+      const audio = document.getElementById('somModoDesbloqueado');
+      if (audio) { audio.currentTime = 0; audio.play(); }
+      completedModes[selectedMode] = true;
+      localStorage.setItem('completedModes', JSON.stringify(completedModes));
+      updateModeIcons();
+    }
   }
 }
 
@@ -822,6 +834,46 @@ function updateClock() {
   el.textContent = now;
 }
 
+function startTutorial() {
+  const welcome = document.getElementById('somWelcome');
+  if (welcome) setTimeout(() => { welcome.currentTime = 0; welcome.play(); }, 1);
+
+  const tutorialLogo = document.getElementById('tutorial-logo');
+  const logoTop = document.getElementById('logo-top');
+  const levelIcon = document.getElementById('nivel-indicador');
+  const menuIcons = document.querySelectorAll('#menu-modes img');
+
+  if (levelIcon) levelIcon.style.display = 'none';
+  if (tutorialLogo) {
+    tutorialLogo.style.display = 'block';
+    tutorialLogo.style.width = '20vw';
+    tutorialLogo.style.transition = 'width 750ms linear';
+    setTimeout(() => { tutorialLogo.style.width = '30vw'; }, 0);
+    setTimeout(() => { tutorialLogo.style.display = 'none'; }, 751);
+  }
+
+  menuIcons.forEach(img => { img.style.opacity = '0'; });
+
+  setTimeout(() => {
+    menuIcons.forEach(img => {
+      img.style.transition = 'opacity 2000ms linear';
+      img.style.opacity = '0.3';
+    });
+  }, 4000);
+
+  const mode1 = document.querySelector('#menu-modes img[data-mode="1"]');
+  setTimeout(() => {
+    if (mode1) { mode1.style.transition = 'opacity 300ms linear'; mode1.style.opacity = '1'; }
+  }, 7500);
+
+  setTimeout(() => {
+    if (mode1) { mode1.style.transition = 'opacity 250ms linear'; mode1.style.opacity = '0.3'; }
+  }, 7850);
+
+  setTimeout(() => { if (levelIcon) levelIcon.style.display = 'block'; }, 11420);
+  setTimeout(() => { if (logoTop) logoTop.style.display = 'block'; }, 11421);
+}
+
 
 window.onload = async () => {
   const saved = parseInt(localStorage.getItem('pastaAtual'), 10);
@@ -831,6 +883,7 @@ window.onload = async () => {
   updateModeIcons();
   updateClock();
   setInterval(updateClock, 1000);
+  startTutorial();
 
   document.querySelectorAll('#mode-buttons img, #menu-modes img').forEach(img => {
     img.addEventListener('click', () => {


### PR DESCRIPTION
## Summary
- add `logo-top` and `tutorial-logo` elements to page
- play new audio cues (`welcome`, `mododesbloqueado`, `niveldesbloqueado`)
- style new logo elements in CSS
- implement tutorial timeline animation
- trigger unlock sounds based on number of modes completed
- update level-up check to use new audio

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_688c481c9994832585f0fa714b57c3f6