### PR TITLE
Implement one-time tutorial and remove clock

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -43,17 +43,6 @@ body.dark-mode #intro-overlay {
   height: 100vh;
 }
 
-#clock {
-  font-size: clamp(40px, 8vw, 80px);
-  font-family: 'Open Sans', sans-serif;
-  font-weight: normal;
-  color: #000;
-  text-align: center;
-}
-
-body.dark-mode #clock {
-  color: #fff;
-}
 
 #menu-modes {
   display: grid;
@@ -241,9 +230,6 @@ body.dark-mode #clock {
     height: 40px;
   }
 
-  #clock {
-    font-size: 12vw;
-  }
 
   #menu-modes {
     grid-template-columns: repeat(3, 1fr);
@@ -264,4 +250,26 @@ body.dark-mode #clock {
 @keyframes modeZoom {
   from { transform: scale(0.8); }
   to { transform: scale(1); }
+}
+
+#logo-top {
+  position: absolute;
+  top: 20px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 100px;
+  height: auto;
+  z-index: 1000;
+  display: none;
+}
+
+#tutorial-logo {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 20vw;
+  height: auto;
+  z-index: 10000;
+  display: none;
 }

--- a/index.html
+++ b/index.html
@@ -9,8 +9,9 @@
 </head>
 <body>
   <img id="nivel-indicador" alt="Level" />
+  <img id="logo-top" src="selos%20modos%20de%20jogo/logoitalk.png" alt="Logo Italk" style="display:none" />
+  <img id="tutorial-logo" src="selos%20modos%20de%20jogo/logoitalk.png" alt="Logo Italk" style="display:none" />
   <div id="menu">
-    <div id="clock"></div>
     <div id="menu-modes">
       <img src="selos%20modos%20de%20jogo/modo1.png" data-mode="1" alt="Modo 1">
       <img src="selos%20modos%20de%20jogo/modo2.png" data-mode="2" alt="Modo 2">
@@ -62,6 +63,10 @@
   <audio id="somModo6Intro" src="gamesounds/mode6first.mp3"></audio>
   <audio id="somNextLevel" src="gamesounds/nextlevel.mp3"></audio>
   <audio id="somLetsPlay" src="gamesounds/letsplay.mp3"></audio>
+
+  <audio id="somWelcome" src="gamesounds/welcome.mp3"></audio>
+  <audio id="somModoDesbloqueado" src="gamesounds/mododesbloqueado.mp3"></audio>
+  <audio id="somNivelDesbloqueado" src="gamesounds/niveldesbloqueado.mp3"></audio>
 
   <audio id="somAcerto" src="gamesounds/success.mp3"></audio>
   <audio id="somErro" src="gamesounds/error.mp3"></audio>


### PR DESCRIPTION
## Summary
- remove clock from menu and use Italk logo instead
- make tutorial run only once using localStorage flag
- adjust tutorial timeline to hide menu icons until 4s
- skip level-up check while tutorial is active
- play welcome audio at 1ms

## Testing
- `node -v`


------
https://chatgpt.com/codex/tasks/task_e_688c481c9994832585f0fa714b57c3f6