### PR TITLE
Adjust tutorial display and menu logo

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -51,6 +51,15 @@ body.dark-mode #intro-overlay {
   text-align: center;
 }
 
+#menu-logo {
+  width: 100px;
+  height: auto;
+}
+
+body.dark-mode #menu-logo {
+  filter: invert(1);
+}
+
 body.dark-mode #clock {
   color: #fff;
 }

--- a/index.html
+++ b/index.html
@@ -9,10 +9,10 @@
 </head>
 <body>
   <img id="nivel-indicador" alt="Level" />
-  <img id="logo-top" src="logoitalk.png" alt="Logo Italk" style="display:none" />
+  <img id="logo-top" src="selos%20modos%20de%20jogo/logoitalk2.png" alt="Logo Italk" style="display:none" />
   <img id="tutorial-logo" src="logoitalk.png" alt="Logo Italk" style="display:none" />
   <div id="menu">
-    <div id="clock"></div>
+    <img id="menu-logo" src="selos%20modos%20de%20jogo/logoitalk.png" alt="Logo Italk" />
     <div id="menu-modes">
       <img src="selos%20modos%20de%20jogo/modo1.png" data-mode="1" alt="Modo 1">
       <img src="selos%20modos%20de%20jogo/modo2.png" data-mode="2" alt="Modo 2">

--- a/js/main.js
+++ b/js/main.js
@@ -148,6 +148,8 @@ let awaitingRetry = false;
 let retryCallback = null;
 let tryAgainColorInterval = null;
 let levelUpReady = false;
+let tutorialInProgress = false;
+let tutorialDone = localStorage.getItem('tutorialDone') === 'true';
 
 const modeImages = {
   1: 'selos%20modos%20de%20jogo/modo1.png',
@@ -195,6 +197,7 @@ function updateModeIcons() {
 }
 
 function checkForMenuLevelUp() {
+  if (tutorialInProgress) return;
   const menu = document.getElementById('menu');
   if (!menu || menu.style.display === 'none') return;
   const allComplete = [1,2,3,4,5,6].every(m => completedModes[m]);
@@ -835,6 +838,8 @@ function updateClock() {
 }
 
 function startTutorial() {
+  tutorialInProgress = true;
+  localStorage.setItem('tutorialDone', 'true');
   const welcome = document.getElementById('somWelcome');
   if (welcome) setTimeout(() => { welcome.currentTime = 0; welcome.play(); }, 1);
 
@@ -842,8 +847,10 @@ function startTutorial() {
   const logoTop = document.getElementById('logo-top');
   const levelIcon = document.getElementById('nivel-indicador');
   const menuIcons = document.querySelectorAll('#menu-modes img');
+  const menuLogo = document.getElementById('menu-logo');
 
   if (levelIcon) levelIcon.style.display = 'none';
+  if (menuLogo) menuLogo.style.display = 'none';
   if (tutorialLogo) {
     tutorialLogo.style.display = 'block';
     tutorialLogo.style.width = '20vw';
@@ -871,7 +878,11 @@ function startTutorial() {
   }, 7850);
 
   setTimeout(() => { if (levelIcon) levelIcon.style.display = 'block'; }, 11420);
-  setTimeout(() => { if (logoTop) logoTop.style.display = 'block'; }, 11421);
+  setTimeout(() => {
+    if (logoTop) logoTop.style.display = 'block';
+    if (menuLogo) menuLogo.style.display = 'block';
+    tutorialInProgress = false;
+  }, 11421);
 }
 
 
@@ -881,9 +892,16 @@ window.onload = async () => {
   await carregarPastas();
   updateLevelIcon();
   updateModeIcons();
-  updateClock();
-  setInterval(updateClock, 1000);
-  startTutorial();
+  if (!tutorialDone) {
+    startTutorial();
+  } else {
+    const logoTop = document.getElementById('logo-top');
+    const levelIcon = document.getElementById('nivel-indicador');
+    const menuLogo = document.getElementById('menu-logo');
+    if (logoTop) logoTop.style.display = 'block';
+    if (levelIcon) levelIcon.style.display = 'block';
+    if (menuLogo) menuLogo.style.display = 'block';
+  }
 
   document.querySelectorAll('#mode-buttons img, #menu-modes img').forEach(img => {
     img.addEventListener('click', () => {


### PR DESCRIPTION
## Summary
- change the top logo to `logoitalk2.png`
- replace menu clock with `logoitalk.png`
- add styles for `menu-logo`
- save tutorial completion and show it only once
- hide menu elements during tutorial and reveal after
- prevent `niveldesbloqueado` audio during tutorial

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688c51e16b208325b483a2d7eefbb2e9