### PR TITLE
Implement ilife intro screen

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -296,3 +296,37 @@ body.dark-mode #clock {
   z-index: 10000;
   display: none;
 }
+
+#ilife-screen {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: #fff;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  z-index: 10000;
+}
+
+#ilife-logo {
+  width: 20%;
+  height: auto;
+  opacity: 0;
+  animation: fadeIn 1000ms forwards;
+}
+
+#ilife-text {
+  margin-top: 10px;
+  color: #777;
+  font-family: 'Open Sans', sans-serif;
+  font-weight: normal;
+  font-size: 14px;
+}
+
+@keyframes fadeIn {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}

--- a/index.html
+++ b/index.html
@@ -8,11 +8,15 @@
   <link rel="stylesheet" href="css/style.css">
 </head>
 <body>
+  <div id="ilife-screen" style="display:none">
+    <img id="ilife-logo" src="selos%20modos%20de%20jogo/logoitalk2.png" alt="Logo Italk">
+    <div id="ilife-text">diga play para começar</div>
+  </div>
   <img id="nivel-indicador" alt="Level" />
   <img id="logo-top" src="selos%20modos%20de%20jogo/logoitalk2.png" alt="Logo Italk" style="display:none" />
-  <img id="tutorial-logo" src="logoitalk.png" alt="Logo Italk" style="display:none" />
+  <img id="tutorial-logo" src="selos%20modos%20de%20jogo/logoitalk2.png" alt="Logo Italk" style="display:none" />
   <div id="menu">
-    <img id="menu-logo" src="selos%20modos%20de%20jogo/logoitalk.png" alt="Logo Italk" />
+    <img id="menu-logo" src="selos%20modos%20de%20jogo/logoitalk2.png" alt="Logo Italk" />
     <div id="menu-modes">
       <img src="selos%20modos%20de%20jogo/modo1.png" data-mode="1" alt="Modo 1">
       <img src="selos%20modos%20de%20jogo/modo2.png" data-mode="2" alt="Modo 2">

--- a/js/main.js
+++ b/js/main.js
@@ -75,6 +75,18 @@ if ('webkitSpeechRecognition' in window || 'SpeechRecognition' in window) {
   reconhecimento.onresult = (event) => {
     const transcript = event.results[event.results.length - 1][0].transcript.trim();
     const normCmd = transcript.toLowerCase().normalize('NFD').replace(/[\u0300-\u036f]/g, '');
+    if (ilifeActive) {
+      ilifeActive = false;
+      localStorage.setItem('ilifeDone', 'true');
+      const screen = document.getElementById('ilife-screen');
+      const menu = document.getElementById('menu');
+      if (screen) screen.style.display = 'none';
+      if (menu) menu.style.display = 'flex';
+      if (!tutorialDone) {
+        startTutorial();
+      }
+      return;
+    }
     if (awaitingNextLevel && (normCmd.includes('next level') || normCmd.includes('proximo nivel'))) {
       awaitingNextLevel = false;
       if (nextLevelCallback) {
@@ -150,6 +162,8 @@ let tryAgainColorInterval = null;
 let levelUpReady = false;
 let tutorialInProgress = false;
 let tutorialDone = localStorage.getItem('tutorialDone') === 'true';
+let ilifeDone = localStorage.getItem('ilifeDone') === 'true';
+let ilifeActive = false;
 
 const modeImages = {
   1: 'selos%20modos%20de%20jogo/modo1.png',
@@ -179,7 +193,12 @@ const modeIntros = {
 function updateLevelIcon() {
   const icon = document.getElementById('nivel-indicador');
   if (icon) {
-    icon.src = `selos_niveis/level%20${pastaAtual}.png`;
+    icon.style.transition = 'opacity 1000ms linear';
+    icon.style.opacity = '0';
+    setTimeout(() => {
+      icon.src = `selos_niveis/level%20${pastaAtual}.png`;
+      icon.style.opacity = '1';
+    }, 1000);
   }
   localStorage.setItem('pastaAtual', pastaAtual);
 }
@@ -892,7 +911,13 @@ window.onload = async () => {
   await carregarPastas();
   updateLevelIcon();
   updateModeIcons();
-  if (!tutorialDone) {
+  if (!ilifeDone) {
+    const menu = document.getElementById('menu');
+    const screen = document.getElementById('ilife-screen');
+    if (menu) menu.style.display = 'none';
+    if (screen) screen.style.display = 'flex';
+    ilifeActive = true;
+  } else if (!tutorialDone) {
     startTutorial();
   } else {
     const logoTop = document.getElementById('logo-top');


### PR DESCRIPTION
## Summary
- introduce ilife intro overlay that shows on first visit
- fade in logoitalk2.png and prompt user to say "play" to start
- remove references to logoitalk.png and use logoitalk2.png everywhere
- animate level indicator when changing levels

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688c58f27ab483259bdfa6dd39c35f71