### PR TITLE
Adjust mode 1 scoring and remove menu logos

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,10 +13,8 @@
     <div id="ilife-text">diga play para começar</div>
   </div>
   <img id="nivel-indicador" alt="Level" />
-  <img id="logo-top" src="selos%20modos%20de%20jogo/logoitalk2.png" alt="Logo Italk" style="display:none" />
   <img id="tutorial-logo" src="selos%20modos%20de%20jogo/logoitalk2.png" alt="Logo Italk" style="display:none" />
   <div id="menu">
-    <img id="menu-logo" src="selos%20modos%20de%20jogo/logoitalk2.png" alt="Logo Italk" />
     <div id="menu-modes">
       <img src="selos%20modos%20de%20jogo/modo1.png" data-mode="1" alt="Modo 1">
       <img src="selos%20modos%20de%20jogo/modo2.png" data-mode="2" alt="Modo 2">

--- a/js/main.js
+++ b/js/main.js
@@ -141,7 +141,7 @@ let mostrarTexto = 'pt';
 let voz = 'en';
 let esperadoLang = 'pt';
 let timerInterval = null;
-const TOTAL_FRASES = 24;
+const TOTAL_FRASES = 25;
 let selectedMode = 1;
 // Removed difficulty selection; game always starts on easy mode
 const INITIAL_POINTS = 3500;
@@ -378,7 +378,7 @@ function showMode1Intro(callback) {
   const overlay = document.getElementById('intro-overlay');
   const audio = document.getElementById('somModo1Intro');
   const img = document.getElementById('intro-image');
-  points = INITIAL_POINTS;
+  points = 0;
   atualizarBarraProgresso();
   img.style.animation = 'none';
   img.style.transition = 'none';
@@ -555,10 +555,17 @@ function beginGame() {
       reconhecimentoAtivo = true;
       reconhecimento.start();
     }
-    points = INITIAL_POINTS;
-    premioBase = 4000;
-    premioDec = 1;
-    penaltyFactor = 0.5;
+    if (selectedMode === 1) {
+      points = 0;
+      premioBase = 1000;
+      premioDec = 0;
+      penaltyFactor = 0;
+    } else {
+      points = INITIAL_POINTS;
+      premioBase = 4000;
+      premioDec = 1;
+      penaltyFactor = 0.5;
+    }
     carregarFrases();
   };
 
@@ -719,6 +726,23 @@ function verificarResposta() {
     atualizarBarraProgresso();
     return;
   }
+  const resultado = document.getElementById("resultado");
+  tentativasTotais++;
+  const elapsed = Date.now() - prizeStart;
+  const premioAtual = premioBase - elapsed * premioDec;
+
+  if (selectedMode === 1) {
+    document.getElementById("somAcerto").play();
+    acertosTotais++;
+    resultado.textContent = '';
+    points += 1000;
+    flashSuccess(() => {
+      continuar();
+    });
+    atualizarBarraProgresso();
+    return;
+  }
+
   const [pt, en] = frasesArr[fraseIndex];
 
   const norm = t => t.normalize("NFD").replace(/[\u0300-\u036f]/g, "").replace(/[^a-z0-9]/gi, "").toLowerCase();
@@ -732,12 +756,6 @@ function verificarResposta() {
     normalizadoResp === normalizadoEsp ||
     ehQuaseCorreto(normalizadoResp, normalizadoEsp) ||
     ehQuaseCorretoPalavras(resposta, esperado);
-
-  const resultado = document.getElementById("resultado");
-  const acertosDiv = document.getElementById("acertos");
-  tentativasTotais++;
-  const elapsed = Date.now() - prizeStart;
-  const premioAtual = premioBase - elapsed * premioDec;
 
   if (correto) {
     document.getElementById("somAcerto").play();
@@ -970,7 +988,7 @@ window.onload = async () => {
       clearInterval(timerInterval);
       clearInterval(prizeTimer);
       pastaAtual++;
-      points = INITIAL_POINTS;
+      points = selectedMode === 1 ? 0 : INITIAL_POINTS;
       updateLevelIcon();
       beginGame();
     }


### PR DESCRIPTION
## Summary
- remove `logoitalk2.png` references from the menu
- start mode 1 at 0 points
- count 25 phrases and award 1000 points each in mode 1
- no penalties for wrong answers in mode 1

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688c5dbc56ac83258a55ff2ca798a457