### PR TITLE
Unlock modes sequentially

### DIFF
--- a/index.html
+++ b/index.html
@@ -74,6 +74,7 @@
   <audio id="somAcerto" src="gamesounds/success.mp3"></audio>
   <audio id="somErro" src="gamesounds/error.mp3"></audio>
   <audio id="somLevelUp" src="audio/levelup.ogg"></audio>
+  <audio id="somLock" src="gamesounds/lock.wav"></audio>
 
   <script src="js/main.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- add unlockedModes tracking and mode unlocking logic
- fade mode icons when unlocking and on level up
- add finishMode handling to fade out after reaching score threshold
- restrict mode click when locked, play lock sound
- unlock first mode at end of tutorial
- include lock sound element

## Testing
- `node --check js/main.js`

------
https://chatgpt.com/codex/tasks/task_e_688c709e462c8325bd31aa8ad7910440