### PR TITLE
Improve unlock animation timing

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -837,7 +837,7 @@ function finishMode() {
   localStorage.setItem('completedModes', JSON.stringify(completedModes));
   const texto = document.getElementById('texto-exibicao');
   if (texto) {
-    texto.style.transition = 'opacity 1500ms linear';
+    texto.style.transition = 'opacity 1000ms linear';
     texto.style.opacity = '0';
   }
   clearInterval(timerInterval);
@@ -846,7 +846,7 @@ function finishMode() {
     goHome();
     const next = selectedMode + 1;
     if (next <= 6) {
-      unlockMode(next, 1500);
+      unlockMode(next, 1000);
       const audio = document.getElementById('somModoDesbloqueado');
       if (audio) { audio.currentTime = 0; audio.play(); }
     } else {
@@ -854,7 +854,7 @@ function finishMode() {
       if (audio) { audio.currentTime = 0; audio.play(); }
       performMenuLevelUp();
     }
-  }, 1500);
+  }, 1000);
 }
 
 function nextMode() {


### PR DESCRIPTION
## Summary
- adjust `finishMode` unlock sequence to run in 1000ms

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_688c75af2e448325817e0a6f4910eddc