### PR TITLE
Implement continuous unlock flow

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -87,7 +87,7 @@ if ('webkitSpeechRecognition' in window || 'SpeechRecognition' in window) {
       }
       return;
     }
-    if (awaitingNextLevel && (normCmd.includes('next level') || normCmd.includes('proximo nivel'))) {
+    if (awaitingNextLevel) {
       awaitingNextLevel = false;
       if (nextLevelCallback) {
         const cb = nextLevelCallback;
@@ -253,7 +253,7 @@ function performMenuLevelUp() {
   setTimeout(() => {
     pastaAtual++;
     completedModes = {};
-    unlockedModes = {};
+    unlockedModes = { 1: true };
     localStorage.setItem('completedModes', JSON.stringify(completedModes));
     localStorage.setItem('unlockedModes', JSON.stringify(unlockedModes));
     updateLevelIcon();
@@ -837,24 +837,38 @@ function finishMode() {
   localStorage.setItem('completedModes', JSON.stringify(completedModes));
   const texto = document.getElementById('texto-exibicao');
   if (texto) {
-    texto.style.transition = 'opacity 1500ms linear';
+    texto.style.transition = 'opacity 1000ms linear';
     texto.style.opacity = '0';
   }
   clearInterval(timerInterval);
   clearInterval(prizeTimer);
   setTimeout(() => {
-    goHome();
     const next = selectedMode + 1;
-    if (next <= 6) {
-      unlockMode(next, 1500);
-      const audio = document.getElementById('somModoDesbloqueado');
-      if (audio) { audio.currentTime = 0; audio.play(); }
+    if (selectedMode < 6) {
+      if (next <= 6) {
+        unlockMode(next, 500);
+        const audio = document.getElementById('somModoDesbloqueado');
+        if (audio) { audio.currentTime = 0; audio.play(); }
+      }
+      if (texto) {
+        texto.style.transition = 'opacity 0ms linear';
+        texto.style.opacity = '1';
+      }
+      continuar();
     } else {
+      goHome();
       const audio = document.getElementById('somNivelDesbloqueado');
       if (audio) { audio.currentTime = 0; audio.play(); }
-      performMenuLevelUp();
+      awaitingNextLevel = true;
+      nextLevelCallback = performMenuLevelUp;
+      levelUpReady = true;
+      if (reconhecimento) {
+        reconhecimentoAtivo = true;
+        reconhecimento.lang = 'en-US';
+        reconhecimento.start();
+      }
     }
-  }, 1500);
+  }, 1000);
 }
 
 function nextMode() {


### PR DESCRIPTION
## Summary
- trigger level upgrade on any speech once all modes are completed
- keep gameplay running when a mode is finished
- only show menu when finishing mode 6
- always unlock mode 1 after leveling up

## Testing
- `node -c js/main.js`
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_688c75af2e448325817e0a6f4910eddc