### PR TITLE
Gate start command and refine mode progression

### DIFF
--- a/index.html
+++ b/index.html
@@ -71,7 +71,7 @@
   <audio id="somModo5Intro" src="gamesounds/mode5first.mp3"></audio>
   <audio id="somModo6Intro" src="gamesounds/mode6first.mp3"></audio>
   <audio id="somNextLevel" src="gamesounds/nextlevel.mp3"></audio>
-  <audio id="somLetsPlay" src="gamesounds/letsplay.mp3"></audio>
+  <audio id="somWoosh" src="gamesounds/woosh.mp3"></audio>
 
   <audio id="somWelcome" src="gamesounds/welcome.mp3"></audio>
   <audio id="somModoDesbloqueado" src="gamesounds/mododesbloqueado.mp3"></audio>


### PR DESCRIPTION
## Summary
- Start tutorial and gameplay only when the user says "play"
- Play short intro animations on repeat mode visits and remove looping letsplay audio
- Unlock mode 6 and advance levels with new star animation and relaxed phrase matching

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688e2cda67248325a64095e7bd2a39ed