### PR TITLE
Implement star mode level transition

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -9,6 +9,10 @@ body.dark-mode {
   color: #fff;
 }
 
+body.star-mode {
+  background: linear-gradient(180deg, #000, #001533);
+}
+
 body.dark-mode #pt,
 body.dark-mode #texto-exibicao,
 body.dark-mode #resultado,

--- a/js/main.js
+++ b/js/main.js
@@ -932,19 +932,7 @@ function finishMode() {
   const next = selectedMode + 1;
 
   if (selectedMode === 6) {
-    goHome();
-    setTimeout(() => {
-      const img = document.querySelector('#menu-modes img[data-mode="6"]');
-      if (img) {
-        img.style.transition = 'opacity 1000ms linear';
-        img.style.opacity = '0';
-        setTimeout(() => {
-          img.src = 'selos%20modos%20de%20jogo/modostar.png';
-          img.style.opacity = '1';
-          img.addEventListener('click', handleStarClick, { once: true });
-        }, 1000);
-      }
-    }, 500);
+    modoEstrela();
     return;
   }
 
@@ -961,7 +949,25 @@ function finishMode() {
   updateModeIcons();
 }
 
+function modoEstrela() {
+  goHome();
+  document.body.classList.add('star-mode');
+  setTimeout(() => {
+    const img = document.querySelector('#menu-modes img[data-mode="6"]');
+    if (img) {
+      img.style.transition = 'opacity 1000ms linear';
+      img.style.opacity = '0';
+      setTimeout(() => {
+        img.src = 'selos%20modos%20de%20jogo/modostar.png';
+        img.style.opacity = '1';
+        img.addEventListener('click', handleStarClick, { once: true });
+      }, 1000);
+    }
+  }, 500);
+}
+
 function handleStarClick() {
+  document.body.classList.remove('star-mode');
   const starImg = document.querySelector('#menu-modes img[data-mode="6"]');
   const icons = document.querySelectorAll('#menu-modes img');
   icons.forEach(img => {


### PR DESCRIPTION
## Summary
- Add `modoEstrela` to show star menu after completing mode 6
- Style star menu with dark gradient background
- Restore default menu and advance level when star icon clicked

## Testing
- `npm test` (fails: package.json not found)
- `node -c js/main.js`


------
https://chatgpt.com/codex/tasks/task_e_688e3f45ac78832593aee83cf00fc483