### PR TITLE
Switch mode 6 icon after completion and default to dark theme

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1,6 +1,6 @@
 body {
   margin: 0;
-  background: #fff;
+  background: #F8F8FA;
   font-family: 'Open Sans', sans-serif;
 }
 

--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
   <link href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@400;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="css/style.css">
 </head>
-<body>
+<body class="dark-mode">
   <nav id="top-nav">
     <a href="#">home</a>
     <a href="#">fun</a>

--- a/js/main.js
+++ b/js/main.js
@@ -106,15 +106,18 @@ if ('webkitSpeechRecognition' in window || 'SpeechRecognition' in window) {
         retryCallback = null;
         cb();
       }
-    } else if (normCmd.includes('next level') || normCmd.includes('proximo nivel')) {
-      points += 25000;
-      if (selectedMode === 6 && points >= COMPLETION_THRESHOLD && !nextLevelSoundPlayed) {
-        const audio = document.getElementById('somNextLevel');
-        if (audio) { audio.currentTime = 0; audio.play(); }
-        nextLevelSoundPlayed = true;
-      }
-      atualizarBarraProgresso();
-    } else if (listeningForCommand) {
+      } else if (normCmd.includes('next level') || normCmd.includes('proximo nivel')) {
+        points += 25000;
+        if (selectedMode === 6 && points >= COMPLETION_THRESHOLD && !nextLevelSoundPlayed) {
+          const audio = document.getElementById('somNextLevel');
+          if (audio) { audio.currentTime = 0; audio.play(); }
+          nextLevelSoundPlayed = true;
+        }
+        atualizarBarraProgresso();
+        if (points >= COMPLETION_THRESHOLD && !completedModes[selectedMode]) {
+          finishMode();
+        }
+      } else if (listeningForCommand) {
       if (normCmd.includes('play')) {
         listeningForCommand = false;
         startGame(getHighestUnlockedMode());
@@ -925,6 +928,26 @@ function atualizarBarraProgresso() {
   }
 }
 
+function upgradeMode6Icon(animated = false) {
+  const starSrc = 'selos%20modos%20de%20jogo/modostar.png';
+  modeImages[6] = starSrc;
+  if (modeTransitions[5]) modeTransitions[5].img = starSrc;
+  document.querySelectorAll('img[data-mode="6"]').forEach(img => {
+    if (animated && img.closest('#menu-modes')) {
+      img.style.transition = 'opacity 1000ms linear';
+      img.style.opacity = '0';
+      setTimeout(() => {
+        img.src = starSrc;
+        img.style.opacity = '1';
+      }, 1000);
+    } else {
+      img.src = starSrc;
+    }
+  });
+  const menuImg = document.querySelector('#menu-modes img[data-mode="6"]');
+  if (menuImg) menuImg.addEventListener('click', handleStarClick, { once: true });
+}
+
 function finishMode() {
   if (completedModes[selectedMode]) return;
   completedModes[selectedMode] = true;
@@ -933,18 +956,7 @@ function finishMode() {
 
   if (selectedMode === 6) {
     goHome();
-    setTimeout(() => {
-      const img = document.querySelector('#menu-modes img[data-mode="6"]');
-      if (img) {
-        img.style.transition = 'opacity 1000ms linear';
-        img.style.opacity = '0';
-        setTimeout(() => {
-          img.src = 'selos%20modos%20de%20jogo/modostar.png';
-          img.style.opacity = '1';
-          img.addEventListener('click', handleStarClick, { once: true });
-        }, 1000);
-      }
-    }, 500);
+    setTimeout(() => upgradeMode6Icon(true), 500);
     return;
   }
 
@@ -1091,6 +1103,7 @@ window.onload = async () => {
   await carregarPastas();
   updateLevelIcon();
   updateModeIcons();
+  if (completedModes[6]) upgradeMode6Icon();
   if (!ilifeDone) {
     const menu = document.getElementById('menu');
     const screen = document.getElementById('ilife-screen');


### PR DESCRIPTION
## Summary
- Swap mode 6 icon to a star across menus after reaching 25k points
- Set dark mode as default and lighten light mode background

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check js/main.js`


------
https://chatgpt.com/codex/tasks/task_e_688e455b6e1c8325979547b7c177c6e4