### PR TITLE
Add star unlock for mode 6 and resize mode icons

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -91,14 +91,14 @@ body.dark-mode #clock {
 
 #menu-modes {
   display: grid;
-  grid-template-columns: repeat(3, 175px);
-  grid-auto-rows: 175px;
+  grid-template-columns: repeat(3, 227px);
+  grid-auto-rows: 227px;
   gap: 50px;
 }
 
 #menu-modes img {
-  width: 175px;
-  height: 175px;
+  width: 227px;
+  height: 227px;
   object-fit: contain;
   cursor: pointer;
   opacity: 0.3;
@@ -254,7 +254,7 @@ body.dark-mode #clock {
 
 #mode-buttons {
   position: fixed;
-  bottom: 85px;
+  bottom: 135px;
   left: 0;
   width: 100%;
   display: flex;
@@ -264,8 +264,8 @@ body.dark-mode #clock {
 }
 
 #mode-buttons img {
-  width: 90px;
-  height: 90px;
+  width: 117px;
+  height: 117px;
   cursor: pointer;
   opacity: 0.35;
   transition: opacity 0.2s linear;
@@ -287,8 +287,8 @@ body.dark-mode #clock {
   }
 
   #menu-modes img {
-    width: 28vw;
-    height: 28vw;
+    width: 36.4vw;
+    height: 36.4vw;
   }
 }
 

--- a/js/main.js
+++ b/js/main.js
@@ -109,7 +109,8 @@ if ('webkitSpeechRecognition' in window || 'SpeechRecognition' in window) {
       } else if (normCmd.includes('next level') || normCmd.includes('proximo nivel')) {
         points += 25000;
         atualizarBarraProgresso();
-        if (selectedMode !== 6 && points >= COMPLETION_THRESHOLD && !completedModes[selectedMode]) {
+        const threshold = selectedMode === 6 ? MODE6_THRESHOLD : COMPLETION_THRESHOLD;
+        if (points >= threshold && !completedModes[selectedMode]) {
           finishMode();
         }
       } else if (listeningForCommand) {
@@ -156,6 +157,7 @@ let selectedMode = 1;
 // Removed difficulty selection; game always starts on easy mode
 const INITIAL_POINTS = 3500;
 const COMPLETION_THRESHOLD = 25000;
+const MODE6_THRESHOLD = 25115;
 let completedModes = JSON.parse(localStorage.getItem('completedModes') || '{}');
 let unlockedModes = JSON.parse(localStorage.getItem('unlockedModes') || '{}');
 let modeIntroShown = JSON.parse(localStorage.getItem('modeIntroShown') || '{}');
@@ -366,7 +368,8 @@ function startIntroProgress(duration) {
   const start = Date.now();
   introProgressInterval = setInterval(() => {
     const ratio = Math.min((Date.now() - start) / duration, 1);
-    const pontos = ratio * 25000;
+    const limite = selectedMode === 6 ? MODE6_THRESHOLD : 25000;
+    const pontos = ratio * limite;
     filled.style.width = (ratio * 100) + '%';
     filled.style.backgroundColor = calcularCor(pontos);
     if (ratio >= 1) clearInterval(introProgressInterval);
@@ -387,7 +390,7 @@ function startTryAgainAnimation() {
   if (!msg) return;
   if (tryAgainColorInterval) clearInterval(tryAgainColorInterval);
   const duration = 30000;
-  const maxPoints = 25000;
+  const maxPoints = selectedMode === 6 ? MODE6_THRESHOLD : 25000;
   const begin = Date.now();
   tryAgainColorInterval = setInterval(() => {
     const elapsed = (Date.now() - begin) % duration;
@@ -578,7 +581,8 @@ function beginGame() {
     const icon = document.getElementById('mode-icon');
     if (icon) {
       icon.src = modeImages[selectedMode];
-      const ratio = Math.max(0, Math.min(points, 25000)) / 25000;
+      const threshold = selectedMode === 6 ? MODE6_THRESHOLD : COMPLETION_THRESHOLD;
+      const ratio = Math.max(0, Math.min(points, threshold)) / threshold;
       icon.style.opacity = ratio;
       icon.style.display = 'block';
     }
@@ -817,7 +821,8 @@ function verificarResposta() {
     points += 25000;
     input.value = '';
     atualizarBarraProgresso();
-    if (selectedMode !== 6 && points >= COMPLETION_THRESHOLD && !completedModes[selectedMode]) {
+    const threshold = selectedMode === 6 ? MODE6_THRESHOLD : COMPLETION_THRESHOLD;
+    if (points >= threshold && !completedModes[selectedMode]) {
       finishMode();
     }
     return;
@@ -832,7 +837,8 @@ function verificarResposta() {
     acertosTotais++;
     resultado.textContent = '';
     points += 1000;
-    const reached = selectedMode !== 6 && points >= COMPLETION_THRESHOLD && !completedModes[selectedMode];
+    const threshold = selectedMode === 6 ? MODE6_THRESHOLD : COMPLETION_THRESHOLD;
+    const reached = points >= threshold && !completedModes[selectedMode];
     flashSuccess(() => {
       if (reached) finishMode();
       else continuar();
@@ -863,7 +869,8 @@ function verificarResposta() {
     if (selectedMode === 5) {
       points += 1000;
     }
-    const reached = selectedMode !== 6 && points >= COMPLETION_THRESHOLD && !completedModes[selectedMode];
+    const threshold = selectedMode === 6 ? MODE6_THRESHOLD : COMPLETION_THRESHOLD;
+    const reached = points >= threshold && !completedModes[selectedMode];
     flashSuccess(() => {
       if (reached) finishMode();
       else continuar();
@@ -900,7 +907,7 @@ function atualizarBarraProgresso() {
   const premioAtual = premioBase - (Date.now() - prizeStart) * premioDec;
   document.getElementById('score').textContent = `PREMIO (${Math.round(premioAtual)}) pontos: (${Math.round(points)})`;
   const filled = document.getElementById('barra-preenchida');
-  const limite = 25000;
+  const limite = selectedMode === 6 ? MODE6_THRESHOLD : COMPLETION_THRESHOLD;
   const perc = Math.max(0, Math.min(points, limite)) / limite * 100;
   filled.style.width = perc + '%';
   filled.style.backgroundColor = calcularCor(points);
@@ -926,6 +933,17 @@ function finishMode() {
   }
 
   updateModeIcons();
+
+  if (selectedMode === 6) {
+    document.querySelectorAll('#menu-modes img[data-mode="6"], #mode-buttons img[data-mode="6"]').forEach(img => {
+      img.style.transition = 'opacity 1000ms linear';
+      img.style.opacity = '0';
+      setTimeout(() => {
+        img.src = 'selos%20modos%20de%20jogo/modostar.png';
+        img.style.opacity = '1';
+      }, 1000);
+    });
+  }
 }
 
 function nextMode() {


### PR DESCRIPTION
## Summary
- Show a star icon when mode 6 reaches 25,115 points
- Enlarge and raise mode icons in the interface

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688e689aedc08325977630194099db4a