### PR TITLE
feat: add gradient background and tutorial mode fades

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1,6 +1,6 @@
 body {
   margin: 0;
-  background: #F8F8FA;
+  background: linear-gradient(to bottom, #ffffff 0%, #f0f0f0 100%);
   font-family: 'Open Sans', sans-serif;
 }
 

--- a/js/main.js
+++ b/js/main.js
@@ -1038,6 +1038,21 @@ function startTutorial() {
     });
   }, 4000);
 
+  setTimeout(() => {
+    const seq = [1, 2, 3, 4, 5, 6].map(n => document.querySelector(`#menu-modes img[data-mode="${n}"]`));
+    seq.forEach((img, idx) => {
+      setTimeout(() => {
+        if (!img) return;
+        img.style.transition = 'opacity 200ms linear';
+        img.style.opacity = '0.99';
+        setTimeout(() => {
+          img.style.transition = 'opacity 200ms linear';
+          img.style.opacity = '0.3';
+        }, 200);
+      }, idx * 450);
+    });
+  }, 7000);
+
   const mode1 = document.querySelector('#menu-modes img[data-mode="1"]');
 
   setTimeout(() => { if (levelIcon) levelIcon.style.display = 'block'; }, 11420);


### PR DESCRIPTION
## Summary
- apply light gray to white gradient for light theme background
- animate mode icons during tutorial with sequential fade effects after welcome audio

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688e91946a808325854d6325b61293a3