### PR TITLE
Add reporting command and mode 1 statistics

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -47,6 +47,18 @@ body.dark-mode #intro-overlay {
   background: #000;
 }
 
+.custom-title {
+  font-family: 'Open Sans', sans-serif;
+  font-size: 15px;
+}
+
+.custom-info {
+  font-family: 'Open Sans', sans-serif;
+  font-weight: 700;
+  font-size: 12px;
+  margin: 5px 0;
+}
+
 #visor {
   position: relative;
   display: flex;

--- a/custom.html
+++ b/custom.html
@@ -15,7 +15,14 @@
     <a href="custom.html">custom</a>
   </nav>
   <div id="custom-content" style="text-align:center;margin-top:50px;">
-    <h2>Tempo total jogado: <span id="total-time">0s</span></h2>
+    <h1 class="custom-title">Modo 1 - Resultados</h1>
+    <div class="custom-info">Frases totais: <span id="m1-total">0</span></div>
+    <div class="custom-info">Tempo de jogo: <span id="m1-time">0s</span></div>
+    <div class="custom-info">Frases acertadas: <span id="m1-correct">0</span></div>
+    <div class="custom-info">Frases erradas: <span id="m1-wrong">0</span></div>
+    <div class="custom-info">Porcentagem de acertos: <span id="m1-acc">0%</span></div>
+    <div class="custom-info">Média de tempo por frase: <span id="m1-avg">0s</span></div>
+    <div class="custom-info">Uso de reportar: <span id="m1-report">0%</span></div>
   </div>
   <script>
     function formatTime(ms) {
@@ -25,8 +32,22 @@
       return `${min}m ${s}s`;
     }
     document.addEventListener('DOMContentLoaded', () => {
-      const ms = parseInt(localStorage.getItem('totalTime') || '0', 10);
-      document.getElementById('total-time').textContent = formatTime(ms);
+      const stats = JSON.parse(localStorage.getItem('mode1Stats') || '{}');
+      const totalTime = stats.totalTime || 0;
+      const total = stats.totalPhrases || 0;
+      const correct = stats.correct || 0;
+      const wrong = stats.wrong || 0;
+      const report = stats.report || 0;
+      const acc = total ? ((correct / total) * 100).toFixed(2) : '0';
+      const avg = total ? formatTime(totalTime / total) : '0s';
+      const reportPerc = total ? ((report / total) * 100).toFixed(2) : '0';
+      document.getElementById('m1-total').textContent = total;
+      document.getElementById('m1-time').textContent = formatTime(totalTime);
+      document.getElementById('m1-correct').textContent = correct;
+      document.getElementById('m1-wrong').textContent = wrong;
+      document.getElementById('m1-acc').textContent = acc + '%';
+      document.getElementById('m1-avg').textContent = avg;
+      document.getElementById('m1-report').textContent = reportPerc + '%';
     });
   </script>
 </body>


### PR DESCRIPTION
## Summary
- Allow players to say "report"/"reportar" to convert the most recent mistake into a correct answer and tally usage.
- Track mode 1 gameplay statistics like total phrases, time played, accuracy, and report usage.
- Display mode 1 results in the custom menu using Open Sans fonts.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688e980447188325b9a5320fbc4aaa2b