### PR TITLE
Track stats for all game modes

### DIFF
--- a/custom.html
+++ b/custom.html
@@ -14,16 +14,7 @@
     <a href="#">play</a>
     <a href="custom.html">custom</a>
   </nav>
-  <div id="custom-content" style="text-align:center;margin-top:50px;">
-    <h1 class="custom-title">Modo 1 - Resultados</h1>
-    <div class="custom-info">Frases totais: <span id="m1-total">0</span></div>
-    <div class="custom-info">Tempo de jogo: <span id="m1-time">0s</span></div>
-    <div class="custom-info">Frases acertadas: <span id="m1-correct">0</span></div>
-    <div class="custom-info">Frases erradas: <span id="m1-wrong">0</span></div>
-    <div class="custom-info">Porcentagem de acertos: <span id="m1-acc">0%</span></div>
-    <div class="custom-info">Média de tempo por frase: <span id="m1-avg">0s</span></div>
-    <div class="custom-info">Uso de reportar: <span id="m1-report">0%</span></div>
-  </div>
+  <div id="custom-content" style="text-align:center;margin-top:50px;"></div>
   <script>
     function formatTime(ms) {
       const sec = Math.floor(ms / 1000);
@@ -32,22 +23,31 @@
       return `${min}m ${s}s`;
     }
     document.addEventListener('DOMContentLoaded', () => {
-      const stats = JSON.parse(localStorage.getItem('mode1Stats') || '{}');
-      const totalTime = stats.totalTime || 0;
-      const total = stats.totalPhrases || 0;
-      const correct = stats.correct || 0;
-      const wrong = stats.wrong || 0;
-      const report = stats.report || 0;
-      const acc = total ? ((correct / total) * 100).toFixed(2) : '0';
-      const avg = total ? formatTime(totalTime / total) : '0s';
-      const reportPerc = total ? ((report / total) * 100).toFixed(2) : '0';
-      document.getElementById('m1-total').textContent = total;
-      document.getElementById('m1-time').textContent = formatTime(totalTime);
-      document.getElementById('m1-correct').textContent = correct;
-      document.getElementById('m1-wrong').textContent = wrong;
-      document.getElementById('m1-acc').textContent = acc + '%';
-      document.getElementById('m1-avg').textContent = avg;
-      document.getElementById('m1-report').textContent = reportPerc + '%';
+      const container = document.getElementById('custom-content');
+      const statsData = JSON.parse(localStorage.getItem('modeStats') || '{}');
+      for (let i = 1; i <= 6; i++) {
+        const stats = statsData[i] || {};
+        const totalTime = stats.totalTime || 0;
+        const total = stats.totalPhrases || 0;
+        const correct = stats.correct || 0;
+        const wrong = stats.wrong || 0;
+        const report = stats.report || 0;
+        const acc = total ? ((correct / total) * 100).toFixed(2) : '0';
+        const avg = total ? formatTime(totalTime / total) : '0s';
+        const reportPerc = total ? ((report / total) * 100).toFixed(2) : '0';
+        const section = document.createElement('div');
+        section.innerHTML = `
+          <h1 class="custom-title">Modo ${i} - Resultados</h1>
+          <div class="custom-info">Frases totais: ${total}</div>
+          <div class="custom-info">Tempo de jogo: ${formatTime(totalTime)}</div>
+          <div class="custom-info">Frases acertadas: ${correct}</div>
+          <div class="custom-info">Frases erradas: ${wrong}</div>
+          <div class="custom-info">Porcentagem de acertos: ${acc}%</div>
+          <div class="custom-info">Média de tempo por frase: ${avg}</div>
+          <div class="custom-info">Uso de reportar: ${reportPerc}%</div>
+        `;
+        container.appendChild(section);
+      }
     });
   </script>
 </body>

--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
 </head>
 <body class="dark-mode">
   <nav id="top-nav" style="display:none">
-    <a href="#">home</a>
+    <a href="#" id="home-link">home</a>
     <a href="#">fun</a>
     <a href="#">play</a>
     <a href="custom.html">custom</a>


### PR DESCRIPTION
## Summary
- Show stats for all six game modes on the custom page.
- Track time, accuracy, and reports per mode in `main.js`.
- Clicking **home** now returns to the initial menu.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688ea6635bd08325ba2b6b67a518e58b