### PR TITLE
Add play page with circular performance charts

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -380,3 +380,76 @@ body.dark-mode #clock {
   from { opacity: 0; }
   to { opacity: 1; }
 }
+
+/* Play stats page */
+.mode-section {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  margin-bottom: 60px;
+}
+
+.mode-section .mode-image {
+  width: 227px;
+  height: 227px;
+  object-fit: contain;
+  margin-bottom: 20px;
+}
+
+.graphs-row {
+  display: flex;
+  gap: 40px;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+
+.stat-circle {
+  position: relative;
+  width: 120px;
+  height: 160px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.stat-circle svg {
+  width: 120px;
+  height: 120px;
+  transform: rotate(-90deg);
+}
+
+.circle-bg {
+  fill: none;
+  stroke: #444;
+  stroke-width: 15;
+  opacity: 0.3;
+}
+
+.circle-progress {
+  fill: none;
+  stroke-width: 15;
+  stroke-linecap: round;
+}
+
+.circle-value {
+  position: absolute;
+  top: 60px;
+  left: 60px;
+  transform: translate(-50%, -50%);
+  font-family: 'Open Sans', sans-serif;
+  font-size: 20px;
+  font-weight: 700;
+  color: #fff;
+}
+
+.circle-label {
+  margin-top: 10px;
+  font-size: 14px;
+  font-family: 'Open Sans', sans-serif;
+}
+
+.circle-extra {
+  font-size: 12px;
+  font-family: 'Open Sans', sans-serif;
+  margin-top: 4px;
+}

--- a/custom.html
+++ b/custom.html
@@ -11,7 +11,7 @@
   <nav id="top-nav">
     <a href="index.html">home</a>
     <a href="#">fun</a>
-    <a href="#">play</a>
+    <a href="play.html">play</a>
     <a href="custom.html">custom</a>
   </nav>
   <div id="custom-content" style="text-align:center;margin-top:50px;"></div>

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
   <nav id="top-nav" style="display:none">
     <a href="#" id="home-link">home</a>
     <a href="#">fun</a>
-    <a href="#">play</a>
+    <a href="play.html">play</a>
     <a href="custom.html">custom</a>
   </nav>
   <div id="ilife-screen" style="display:none">

--- a/js/play.js
+++ b/js/play.js
@@ -1,0 +1,124 @@
+const colorStops = [
+  [0, '#ff0000'],
+  [2000, '#ff3b00'],
+  [4000, '#ff7f00'],
+  [6000, '#ffb300'],
+  [8000, '#ffe000'],
+  [10000, '#ffff66'],
+  [12000, '#ccff66'],
+  [14000, '#99ff99'],
+  [16000, '#00cc66'],
+  [18000, '#00994d'],
+  [20000, '#00ffff'],
+  [22000, '#66ccff'],
+  [24000, '#0099ff'],
+  [25000, '#0099ff']
+];
+
+function hexToRgb(hex) {
+  const int = parseInt(hex.slice(1), 16);
+  return [int >> 16 & 255, int >> 8 & 255, int & 255];
+}
+
+function rgbToHex(r, g, b) {
+  return '#' + [r, g, b].map(x => x.toString(16).padStart(2, '0')).join('');
+}
+
+function calcularCor(pontos) {
+  const max = colorStops[colorStops.length - 1][0];
+  const p = Math.max(0, Math.min(pontos, max));
+  for (let i = 0; i < colorStops.length - 1; i++) {
+    const [p1, c1] = colorStops[i];
+    const [p2, c2] = colorStops[i + 1];
+    if (p >= p1 && p <= p2) {
+      const ratio = (p - p1) / (p2 - p1);
+      const [r1, g1, b1] = hexToRgb(c1);
+      const [r2, g2, b2] = hexToRgb(c2);
+      const r = Math.round(r1 + ratio * (r2 - r1));
+      const g = Math.round(g1 + ratio * (g2 - g1));
+      const b = Math.round(b1 + ratio * (b2 - b1));
+      return rgbToHex(r, g, b);
+    }
+  }
+  return colorStops[colorStops.length - 1][1];
+}
+
+function colorFromPercent(perc) {
+  const max = colorStops[colorStops.length - 1][0];
+  return calcularCor((perc / 100) * max);
+}
+
+function createStatCircle(perc, label, valueText, extraText) {
+  const wrapper = document.createElement('div');
+  wrapper.className = 'stat-circle';
+  const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+  svg.setAttribute('viewBox', '0 0 120 120');
+  const radius = 45;
+  const circumference = 2 * Math.PI * radius;
+  const bg = document.createElementNS('http://www.w3.org/2000/svg', 'circle');
+  bg.setAttribute('class', 'circle-bg');
+  bg.setAttribute('cx', '60');
+  bg.setAttribute('cy', '60');
+  bg.setAttribute('r', radius);
+  svg.appendChild(bg);
+  const prog = document.createElementNS('http://www.w3.org/2000/svg', 'circle');
+  prog.setAttribute('class', 'circle-progress');
+  prog.setAttribute('cx', '60');
+  prog.setAttribute('cy', '60');
+  prog.setAttribute('r', radius);
+  prog.setAttribute('stroke-dasharray', circumference);
+  const clamped = Math.max(0, Math.min(perc, 100));
+  prog.setAttribute('stroke-dashoffset', circumference * (1 - clamped / 100));
+  prog.style.stroke = colorFromPercent(perc);
+  svg.appendChild(prog);
+  wrapper.appendChild(svg);
+  const value = document.createElement('div');
+  value.className = 'circle-value';
+  value.textContent = valueText;
+  wrapper.appendChild(value);
+  const labelEl = document.createElement('div');
+  labelEl.className = 'circle-label';
+  labelEl.textContent = label;
+  wrapper.appendChild(labelEl);
+  if (extraText) {
+    const extra = document.createElement('div');
+    extra.className = 'circle-extra';
+    extra.textContent = extraText;
+    wrapper.appendChild(extra);
+  }
+  return wrapper;
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  const container = document.getElementById('play-content');
+  const statsData = JSON.parse(localStorage.getItem('modeStats') || '{}');
+  const timeGoals = {1:1.8, 2:2.2, 3:2.2, 4:3.0, 5:3.5, 6:2.0};
+  const MAX_TIME = 6.0;
+  for (let i = 1; i <= 6; i++) {
+    const stats = statsData[i] || {};
+    const total = stats.totalPhrases || 0;
+    const correct = stats.correct || 0;
+    const report = stats.report || 0;
+    const totalTime = stats.totalTime || 0;
+    const accPerc = total ? (correct / total * 100) : 0;
+    const avg = total ? (totalTime / total / 1000) : 0;
+    const goal = timeGoals[i] || 6;
+    let timePerc = total ? ((MAX_TIME - avg) / (MAX_TIME - goal) * 100) : 0;
+    if (avg >= MAX_TIME) timePerc = 0;
+    const notReportPerc = total ? (100 - (report / total * 100)) : 100;
+    const section = document.createElement('div');
+    section.className = 'mode-section';
+    const img = document.createElement('img');
+    img.src = `selos%20modos%20de%20jogo/modo${i}.png`;
+    img.alt = `Modo ${i}`;
+    img.className = 'mode-image';
+    section.appendChild(img);
+    const graphs = document.createElement('div');
+    graphs.className = 'graphs-row';
+    graphs.appendChild(createStatCircle(accPerc, 'Precisão', `${Math.round(accPerc)}%`));
+    graphs.appendChild(createStatCircle(timePerc, 'Tempo', `${Math.round(timePerc)}%`, `(${avg.toFixed(2)})s`));
+    graphs.appendChild(createStatCircle(notReportPerc, 'Report', `${Math.round(notReportPerc)}%`));
+    section.appendChild(graphs);
+    container.appendChild(section);
+  }
+});

--- a/play.html
+++ b/play.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Play</title>
+  <link href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@400;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="css/style.css">
+</head>
+<body class="dark-mode">
+  <nav id="top-nav">
+    <a href="index.html">home</a>
+    <a href="#">fun</a>
+    <a href="play.html">play</a>
+    <a href="custom.html">custom</a>
+  </nav>
+  <div id="play-content" style="text-align:center;margin-top:50px;"></div>
+  <script src="js/play.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add `play.html` showing mode badges and performance circles
- compute accuracy, time, and report stats with color-coded SVG gauges
- style play page and link navigation to it

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688ebdcdf8a883258b0e8af5ad1db027