### PR TITLE
Implement 6s input timeout and phrase rankings

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -453,3 +453,25 @@ body.dark-mode #clock {
   font-family: 'Open Sans', sans-serif;
   margin-top: 4px;
 }
+.ranking-title-blue {
+  color: blue;
+}
+.ranking-title-red {
+  color: red;
+}
+.ranking-table {
+  margin: 10px auto;
+  border-collapse: collapse;
+}
+.ranking-table th, .ranking-table td {
+  border: 1px solid #ccc;
+  padding: 4px 8px;
+  font-size: 12px;
+  font-family: 'Open Sans', sans-serif;
+}
+.ranking-table.blue {
+  color: blue;
+}
+.ranking-table.red {
+  color: red;
+}

--- a/custom.html
+++ b/custom.html
@@ -22,6 +22,24 @@
       const s = sec % 60;
       return `${min}m ${s}s`;
     }
+    function createRankingTable(data, color) {
+      const table = document.createElement('table');
+      table.className = `ranking-table ${color}`;
+      const header = document.createElement('tr');
+      header.innerHTML = '<th>sentença</th><th>pontos</th>';
+      table.appendChild(header);
+      Object.entries(data).sort((a,b) => b[1]-a[1]).forEach(([phrase,count]) => {
+        const row = document.createElement('tr');
+        const td1 = document.createElement('td');
+        td1.textContent = phrase;
+        const td2 = document.createElement('td');
+        td2.textContent = count;
+        row.appendChild(td1);
+        row.appendChild(td2);
+        table.appendChild(row);
+      });
+      return table;
+    }
     document.addEventListener('DOMContentLoaded', () => {
       const container = document.getElementById('custom-content');
       const statsData = JSON.parse(localStorage.getItem('modeStats') || '{}');
@@ -46,6 +64,22 @@
           <div class="custom-info">Média de tempo por frase: ${avg}</div>
           <div class="custom-info">Uso de reportar: ${reportPerc}%</div>
         `;
+        const blue = stats.correctRanking || {};
+        const red = stats.wrongRanking || {};
+        if (Object.keys(blue).length) {
+          const title = document.createElement('h2');
+          title.textContent = 'Ranking azul';
+          title.className = 'ranking-title-blue';
+          section.appendChild(title);
+          section.appendChild(createRankingTable(blue, 'blue'));
+        }
+        if (Object.keys(red).length) {
+          const title = document.createElement('h2');
+          title.textContent = 'Ranking vermelho';
+          title.className = 'ranking-title-red';
+          section.appendChild(title);
+          section.appendChild(createRankingTable(red, 'red'));
+        }
         container.appendChild(section);
       }
     });


### PR DESCRIPTION
## Summary
- Mark phrase mode inputs incorrect after 6s of silence for modes 2-6
- Track expected and user phrases for wrong answers in per-mode rankings
- Display blue/red phrase rankings with counts on the Custom page

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688ecd23d260832581bd7f9e779ac050