### PR TITLE
Add basic login and user storage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/css/style.css
+++ b/css/style.css
@@ -475,3 +475,23 @@ body.dark-mode #clock {
 .ranking-table.red {
   color: red;
 }
+
+#login-screen {
+  display: none;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  height: 100vh;
+}
+
+#login-form {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+#login-form input,
+#login-form button {
+  padding: 8px;
+  font-size: 16px;
+}

--- a/index.html
+++ b/index.html
@@ -14,6 +14,14 @@
     <a href="play.html">play</a>
     <a href="custom.html">custom</a>
   </nav>
+  <div id="login-screen" style="display:none; flex-direction:column; align-items:center; justify-content:center; height:100vh; gap:20px;">
+    <img src="selos%20modos%20de%20jogo/logoitalk2.png" alt="Logo Italk">
+    <form id="login-form" style="display:flex; flex-direction:column; gap:10px;">
+      <input type="text" id="login-username" placeholder="Usuário" required>
+      <input type="password" id="login-password" placeholder="Senha" required>
+      <button type="submit">Entrar</button>
+    </form>
+  </div>
   <div id="ilife-screen" style="display:none">
     <img id="ilife-logo" src="selos%20modos%20de%20jogo/logoitalk2.png" alt="Logo Italk">
     <div id="ilife-text">toque para<br>desbloquear sua fluência</div>
@@ -82,6 +90,7 @@
   <audio id="somLock" src="gamesounds/lock.wav"></audio>
   <audio id="somLevelStar" src="gamesounds/levelstar.mp3"></audio>
 
+  <script src="js/auth.js"></script>
   <script src="js/main.js"></script>
 </body>
 </html>

--- a/js/auth.js
+++ b/js/auth.js
@@ -1,0 +1,62 @@
+let currentUser = null;
+
+async function initAuth() {
+  const nav = document.getElementById('top-nav');
+  const menu = document.getElementById('menu');
+  if (nav) nav.style.display = 'none';
+  if (menu) menu.style.display = 'none';
+
+  const stored = localStorage.getItem('currentUser');
+  if (stored) {
+    currentUser = JSON.parse(stored);
+    if (nav) nav.style.display = 'flex';
+    if (menu) menu.style.display = 'flex';
+    await initGame();
+  } else {
+    const screen = document.getElementById('login-screen');
+    if (screen) screen.style.display = 'flex';
+    const form = document.getElementById('login-form');
+    if (form) form.addEventListener('submit', handleLogin);
+  }
+}
+
+async function handleLogin(e) {
+  e.preventDefault();
+  const username = document.getElementById('login-username').value.trim();
+  const password = document.getElementById('login-password').value.trim();
+  if (!username || !password) return;
+  let res = await fetch('/login', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ username, password })
+  });
+  if (res.status === 404) {
+    res = await fetch('/register', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ username, password })
+    });
+  }
+  if (!res.ok) {
+    alert('Falha no login');
+    return;
+  }
+  currentUser = await res.json();
+  localStorage.setItem('currentUser', JSON.stringify(currentUser));
+  const screen = document.getElementById('login-screen');
+  if (screen) screen.style.display = 'none';
+  const nav = document.getElementById('top-nav');
+  const menu = document.getElementById('menu');
+  if (nav) nav.style.display = 'flex';
+  if (menu) menu.style.display = 'flex';
+  await initGame();
+}
+
+function saveUserPerformance(stats) {
+  if (!currentUser) return;
+  fetch('/stats', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ username: currentUser.username, stats })
+  });
+}

--- a/js/main.js
+++ b/js/main.js
@@ -232,6 +232,9 @@ function ensureModeStats(mode) {
 
 function saveModeStats() {
   localStorage.setItem('modeStats', JSON.stringify(modeStats));
+  if (typeof saveUserPerformance === 'function') {
+    saveUserPerformance(modeStats);
+  }
 }
 
 function recordModeTime(mode) {
@@ -1242,8 +1245,6 @@ async function initGame() {
 }
 
 window.onload = async () => {
-  document.getElementById('top-nav').style.display = 'flex';
-  document.getElementById('menu').style.display = 'flex';
   const homeLink = document.getElementById('home-link');
   if (homeLink) {
     homeLink.addEventListener('click', (e) => {
@@ -1251,5 +1252,5 @@ window.onload = async () => {
       goHome();
     });
   }
-  await initGame();
+  await initAuth();
 };

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "game",
+  "version": "1.0.0",
+  "description": "Game with login",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "dependencies": {
+    "express": "^4.19.2"
+  }
+}

--- a/server.js
+++ b/server.js
@@ -1,0 +1,66 @@
+const express = require('express');
+const fs = require('fs');
+const path = require('path');
+
+const app = express();
+const USERS_FILE = path.join(__dirname, 'data', 'users.json');
+
+app.use(express.json());
+app.use(express.static(__dirname));
+
+function readUsers() {
+  try {
+    return JSON.parse(fs.readFileSync(USERS_FILE, 'utf8'));
+  } catch {
+    return { users: [] };
+  }
+}
+
+function writeUsers(data) {
+  fs.writeFileSync(USERS_FILE, JSON.stringify(data, null, 2));
+}
+
+app.post('/register', (req, res) => {
+  const { username, password } = req.body;
+  if (!username || !password) {
+    return res.status(400).json({ error: 'missing fields' });
+  }
+  const data = readUsers();
+  if (data.users.find(u => u.username === username)) {
+    return res.status(400).json({ error: 'user exists' });
+  }
+  const newUser = { username, password, stats: {} };
+  data.users.push(newUser);
+  writeUsers(data);
+  res.json(newUser);
+});
+
+app.post('/login', (req, res) => {
+  const { username, password } = req.body;
+  const data = readUsers();
+  const user = data.users.find(u => u.username === username && u.password === password);
+  if (!user) {
+    return res.status(404).json({ error: 'not found' });
+  }
+  res.json(user);
+});
+
+app.post('/stats', (req, res) => {
+  const { username, stats } = req.body;
+  if (!username || !stats) {
+    return res.status(400).json({ error: 'missing fields' });
+  }
+  const data = readUsers();
+  const user = data.users.find(u => u.username === username);
+  if (!user) {
+    return res.status(404).json({ error: 'not found' });
+  }
+  user.stats = stats;
+  writeUsers(data);
+  res.json({ status: 'ok' });
+});
+
+const PORT = process.env.PORT || 3000;
+app.listen(PORT, () => {
+  console.log(`Server running on port ${PORT}`);
+});


### PR DESCRIPTION
## Summary
- Add initial login screen with username and password before game start
- Implement basic authentication logic storing users and their stats
- Introduce Express server to persist user data

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/express)*
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688eeef8d2348325a5f091a835d55a19