### PR TITLE
Refactor play stats view

### DIFF
--- a/play.html
+++ b/play.html
@@ -15,6 +15,14 @@
     <a href="custom.html">custom</a>
   </nav>
   <div id="play-content" style="text-align:center;margin-top:50px;"></div>
+  <div id="mode-buttons">
+    <img src="selos%20modos%20de%20jogo/modo1.png" data-mode="1" class="mode-btn" alt="Modo 1" />
+    <img src="selos%20modos%20de%20jogo/modo2.png" data-mode="2" class="mode-btn" alt="Modo 2" />
+    <img src="selos%20modos%20de%20jogo/modo3.png" data-mode="3" class="mode-btn" alt="Modo 3" />
+    <img src="selos%20modos%20de%20jogo/modo4.png" data-mode="4" class="mode-btn" alt="Modo 4" />
+    <img src="selos%20modos%20de%20jogo/modo5.png" data-mode="5" class="mode-btn" alt="Modo 5" />
+    <img src="selos%20modos%20de%20jogo/modo6.png" data-mode="6" class="mode-btn" alt="Modo 6" />
+  </div>
   <script src="js/play.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Add mode selector menu to play page
- Show general average stats for modes 2-6 by default
- Swap charts based on selected mode

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688f19a81a1c8325a75d8a749624e965