### PR TITLE
Fix phrase stats update

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -283,6 +283,13 @@ body.dark-mode #clock {
   transition: opacity 0.2s linear;
 }
 
+#play-content {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 40px;
+}
+
 @media (max-width: 600px) {
   #mode-icon {
     width: 150px;
@@ -405,16 +412,16 @@ body.dark-mode #clock {
 
 .stat-circle {
   position: relative;
-  width: 120px;
-  height: 160px;
+  width: 210px;
+  height: 280px;
   display: flex;
   flex-direction: column;
   align-items: center;
 }
 
 .stat-circle svg {
-  width: 120px;
-  height: 120px;
+  width: 210px;
+  height: 210px;
   transform: rotate(-90deg);
 }
 
@@ -429,29 +436,30 @@ body.dark-mode #clock {
   fill: none;
   stroke-width: 15;
   stroke-linecap: round;
+  transition: stroke-dashoffset 1s;
 }
 
 .circle-value {
   position: absolute;
-  top: 60px;
-  left: 60px;
+  top: 50%;
+  left: 50%;
   transform: translate(-50%, -50%);
   font-family: 'Open Sans', sans-serif;
-  font-size: 20px;
+  font-size: 35px;
   font-weight: 700;
   color: #fff;
 }
 
 .circle-label {
-  margin-top: 10px;
-  font-size: 14px;
+  margin-top: 18px;
+  font-size: 24px;
   font-family: 'Open Sans', sans-serif;
 }
 
 .circle-extra {
-  font-size: 12px;
+  font-size: 21px;
   font-family: 'Open Sans', sans-serif;
-  margin-top: 4px;
+  margin-top: 7px;
 }
 .ranking-title-blue {
   color: blue;

--- a/js/play.js
+++ b/js/play.js
@@ -68,10 +68,13 @@ function createStatCircle(perc, label, valueText, extraText) {
   prog.setAttribute('r', radius);
   prog.setAttribute('stroke-dasharray', circumference);
   const clamped = Math.max(0, Math.min(perc, 100));
-  prog.setAttribute('stroke-dashoffset', circumference * (1 - clamped / 100));
+  prog.setAttribute('stroke-dashoffset', circumference);
   prog.style.stroke = colorFromPercent(perc);
   svg.appendChild(prog);
   wrapper.appendChild(svg);
+  setTimeout(() => {
+    prog.setAttribute('stroke-dashoffset', circumference * (1 - clamped / 100));
+  }, 50);
   const value = document.createElement('div');
   value.className = 'circle-value';
   value.textContent = valueText;
@@ -93,6 +96,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const container = document.getElementById('play-content');
   container.style.transition = 'opacity 0.2s';
   const buttons = document.querySelectorAll('#mode-buttons img');
+  const clickSound = new Audio('gamesounds/mododesbloqueado.mp3');
   const statsData = JSON.parse(localStorage.getItem('modeStats') || '{}');
   const timeGoals = {1:1.8, 2:2.2, 3:2.2, 4:3.0, 5:3.5, 6:2.0};
   const MAX_TIME = 6.0;
@@ -155,7 +159,11 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   buttons.forEach(img => {
-    img.addEventListener('click', () => selectMode(parseInt(img.dataset.mode, 10)));
+    img.addEventListener('click', () => {
+      clickSound.currentTime = 0;
+      clickSound.play();
+      selectMode(parseInt(img.dataset.mode, 10));
+    });
   });
 
   selectMode(1);


### PR DESCRIPTION
## Summary
- ensure each answered phrase updates custom and play statistics
- enlarge and animate play mode stats, with sound on menu selection

## Testing
- `npm test >/tmp/unit.log && tail -n 20 /tmp/unit.log`


------
https://chatgpt.com/codex/tasks/task_e_688f1f232f0c8325b5ff6f87dc09a096