### PR TITLE
Reset scoring per mode and adjust play page layout

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -441,7 +441,7 @@ body.dark-mode #clock {
 
 .circle-value {
   position: absolute;
-  top: 50%;
+  top: calc(50% - 12px);
   left: 50%;
   transform: translate(-50%, -50%);
   font-family: 'Open Sans', sans-serif;

--- a/js/main.js
+++ b/js/main.js
@@ -485,6 +485,9 @@ function startGame(modo) {
     recordModeTime(prevMode);
   }
   selectedMode = modo;
+  points = modo === 1 ? 0 : INITIAL_POINTS;
+  saveTotals();
+  atualizarBarraProgresso();
   updateModeIcons();
   listeningForCommand = false;
   document.getElementById('menu').style.display = 'none';


### PR DESCRIPTION
## Summary
- Reset points to 0 for mode 1 and 3,500 for modes 2-6 whenever a game mode starts
- Shift percentage labels on play stats circles 12px upward for better alignment

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688f2eac79ec8325b1429028950da286