### PR TITLE
Persist user stats and enforce level-up star

### DIFF
--- a/js/auth.js
+++ b/js/auth.js
@@ -60,6 +60,8 @@ async function handleLogin(e) {
 
 function saveUserPerformance(stats) {
   if (!currentUser) return;
+  currentUser.stats = stats;
+  localStorage.setItem('currentUser', JSON.stringify(currentUser));
   fetch('/stats', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },


### PR DESCRIPTION
## Summary
- Ensure user stats persist by syncing currentUser with mode stats on each save
- Add global stopCurrentGame helper to halt recognition and timers during navigation or level changes
- Require star click to advance after mode 6, locking other controls for 5s and auto-clicking if ignored

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688f3ed9552883259a79b96563452be8