### PR TITLE
Implement user registration with email confirmation

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,6 +21,14 @@
       <input type="password" id="login-password" placeholder="Senha" required>
       <button type="submit">Entrar</button>
     </form>
+    <form id="register-form" style="display:none; flex-direction:column; gap:10px;">
+      <input type="text" id="register-username" placeholder="Usuário" required>
+      <input type="email" id="register-email" placeholder="Email" required>
+      <input type="password" id="register-password" placeholder="Senha" required>
+      <button type="submit">Registrar</button>
+    </form>
+    <button id="show-register">Criar conta</button>
+    <button id="show-login" style="display:none">Já tenho conta</button>
   </div>
   <div id="ilife-screen" style="display:none">
     <img id="ilife-logo" src="selos%20modos%20de%20jogo/logoitalk2.png" alt="Logo Italk">

--- a/js/auth.js
+++ b/js/auth.js
@@ -18,6 +18,24 @@ async function initAuth() {
     if (screen) screen.style.display = 'flex';
     const form = document.getElementById('login-form');
     if (form) form.addEventListener('submit', handleLogin);
+    const regForm = document.getElementById('register-form');
+    if (regForm) regForm.addEventListener('submit', handleRegister);
+    const showReg = document.getElementById('show-register');
+    const showLog = document.getElementById('show-login');
+    if (showReg && showLog) {
+      showReg.addEventListener('click', () => {
+        form.style.display = 'none';
+        regForm.style.display = 'flex';
+        showReg.style.display = 'none';
+        showLog.style.display = 'block';
+      });
+      showLog.addEventListener('click', () => {
+        form.style.display = 'flex';
+        regForm.style.display = 'none';
+        showReg.style.display = 'block';
+        showLog.style.display = 'none';
+      });
+    }
   }
 }
 
@@ -27,21 +45,17 @@ async function handleLogin(e) {
   const password = document.getElementById('login-password').value.trim();
   if (!username || !password) return;
   try {
-    const usersRes = await fetch('users/users.json');
-    if (!usersRes.ok) throw new Error('missing users');
-    const data = await usersRes.json();
-    const user = data.users.find(u => u.username === username && u.password === password);
-    if (!user) {
-      alert('Falha no login');
+    const res = await fetch('/login', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ username, password })
+    });
+    if (!res.ok) {
+      if (res.status === 403) alert('Confirme seu email antes de entrar');
+      else alert('Falha no login');
       return;
     }
-    let stats = {};
-    try {
-      const statsRes = await fetch(`users/${username}/stats.json`);
-      if (statsRes.ok) {
-        stats = await statsRes.json();
-      }
-    } catch {}
+    const { stats } = await res.json();
     localStorage.setItem('modeStats', JSON.stringify(stats));
     modeStats = stats;
     currentUser = { username, stats };
@@ -55,6 +69,27 @@ async function handleLogin(e) {
     await initGame();
   } catch (err) {
     alert('Falha no login');
+  }
+}
+
+async function handleRegister(e) {
+  e.preventDefault();
+  const username = document.getElementById('register-username').value.trim();
+  const email = document.getElementById('register-email').value.trim();
+  const password = document.getElementById('register-password').value.trim();
+  if (!username || !email || !password) return;
+  try {
+    const res = await fetch('/register', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ username, email, password })
+    });
+    if (!res.ok) throw new Error('fail');
+    alert('Registro realizado. Confirme seu email.');
+    const showLog = document.getElementById('show-login');
+    if (showLog) showLog.click();
+  } catch (err) {
+    alert('Falha no registro');
   }
 }
 

--- a/users/users.json
+++ b/users/users.json
@@ -1,9 +1,9 @@
 {
   "users": [
-    { "username": "usuario1", "password": "senha01" },
-    { "username": "usuario2", "password": "senha02" },
-    { "username": "usuario3", "password": "senha03" },
-    { "username": "usuario4", "password": "senha04" },
-    { "username": "usuario5", "password": "senha05" }
+    { "username": "usuario1", "password": "senha01", "email": "usuario1@example.com", "confirmed": true },
+    { "username": "usuario2", "password": "senha02", "email": "usuario2@example.com", "confirmed": true },
+    { "username": "usuario3", "password": "senha03", "email": "usuario3@example.com", "confirmed": true },
+    { "username": "usuario4", "password": "senha04", "email": "usuario4@example.com", "confirmed": true },
+    { "username": "usuario5", "password": "senha05", "email": "usuario5@example.com", "confirmed": true }
   ]
 }


### PR DESCRIPTION
## Summary
- Add registration form and toggle to home page
- Implement client-side login/registration flow with fetch-based API calls
- Extend server with email confirmation, token verification and sample user emails

## Testing
- `node server.js`
- `npm test` (fails: no test specified)


------
https://chatgpt.com/codex/tasks/task_e_688f554d10e88325b4405c8e8c5ba2aa