### PR TITLE
Add persistent menu and pause system

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,6 +6,11 @@
   <title>American Life</title>
   <link href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@400;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="css/style.css">
+  <script>
+    if (localStorage.getItem('ilifeDone') === 'true') {
+      document.write('<style>#ilife-screen{display:none;}#menu{display:flex;}</style>');
+    }
+  </script>
 </head>
   <body>
     <nav id="top-nav">


### PR DESCRIPTION
## Summary
- Skip intro screen after first visit and load menu directly on refresh
- Implement pause logic with point penalties and resume via central icon
- Reset game to 3500 points and pause when entering main menu or reaching score limit

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688f70bfe930832599c53aadd695a63a