### PR TITLE
Play star opens stats sequence

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -455,8 +455,18 @@ function enforceStarClick() {
     st.addEventListener('click', () => {
       clearTimeout(timeout);
       all.forEach(el => { el.style.pointerEvents = ''; });
+      startStatsSequence();
     }, { once: true });
   });
+}
+
+function startStatsSequence() {
+  const audio = new Audio('gamesounds/nivel2.mp3');
+  audio.play();
+  setTimeout(() => {
+    localStorage.setItem('statsSequence', 'true');
+    window.location.href = 'play.html';
+  }, 2000);
 }
 
 function menuLevelUpSequence() {

--- a/js/play.js
+++ b/js/play.js
@@ -176,4 +176,14 @@ document.addEventListener('DOMContentLoaded', () => {
   });
 
   selectMode(1);
+
+  const seq = localStorage.getItem('statsSequence');
+  if (seq === 'true') {
+    localStorage.removeItem('statsSequence');
+    let delay = 3000;
+    [2, 3, 4, 5, 6].forEach(mode => {
+      setTimeout(() => selectMode(mode), delay);
+      delay += 1500;
+    });
+  }
 });


### PR DESCRIPTION
## Summary
- Play `nivel2.mp3` when the mode star is clicked after level 6
- After 2s, navigate to the play menu and automatically cycle through mode stats

## Testing
- `npm test` (fails: Error: no test specified)


------
https://chatgpt.com/codex/tasks/task_e_688fb156ee808325934c1f51e5b9d7a0