### PR TITLE
Wait for level intro audio to finish before stats screen

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -462,11 +462,11 @@ function enforceStarClick() {
 
 function startStatsSequence() {
   const audio = new Audio('gamesounds/nivel2.mp3');
-  audio.play();
-  setTimeout(() => {
+  audio.addEventListener('ended', () => {
     localStorage.setItem('statsSequence', 'true');
     window.location.href = 'play.html';
-  }, 2000);
+  });
+  audio.play();
 }
 
 function menuLevelUpSequence() {


### PR DESCRIPTION
## Summary
- let `nivel2.mp3` play to completion before navigating to the stats screen

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688fbb19904c832581bd914b230d19f4