### PR TITLE
Play star opens stats sequence

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -455,8 +455,16 @@ function enforceStarClick() {
     st.addEventListener('click', () => {
       clearTimeout(timeout);
       all.forEach(el => { el.style.pointerEvents = ''; });
+      startStatsSequence();
     }, { once: true });
   });
+}
+
+function startStatsSequence() {
+  localStorage.setItem('statsSequence', 'true');
+  setTimeout(() => {
+    window.location.href = 'play.html';
+  }, 2000);
 }
 
 function menuLevelUpSequence() {

--- a/js/play.js
+++ b/js/play.js
@@ -176,4 +176,18 @@ document.addEventListener('DOMContentLoaded', () => {
   });
 
   selectMode(1);
+
+  const seq = localStorage.getItem('statsSequence');
+  if (seq === 'true') {
+    localStorage.removeItem('statsSequence');
+    setTimeout(() => {
+      const audio = new Audio('gamesounds/nivel2.mp3');
+      audio.play();
+    }, 1);
+    let delay = 3000;
+    [2, 3, 4, 5, 6].forEach(mode => {
+      setTimeout(() => selectMode(mode), delay);
+      delay += 1500;
+    });
+  }
 });


### PR DESCRIPTION
## Summary
- Delay navigation to the play menu by 2s after clicking the star, storing a flag for a stats sequence
- Play `nivel2.mp3` 1ms after the play menu loads, then automatically cycle through mode stats

## Testing
- `npm test` (fails: Error: no test specified)


------
https://chatgpt.com/codex/tasks/task_e_688fb156ee808325934c1f51e5b9d7a0