### PR TITLE
Ajustes de layout e cálculo de médias gerais

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1,6 +1,6 @@
 body {
   margin: 0;
-  background: linear-gradient(to bottom, #ffffff 0%, #f0f0f0 100%);
+  background: linear-gradient(to bottom, #ffffff 0%, #e0e0e0 100%);
   font-family: 'Open Sans', sans-serif;
 }
 
@@ -253,11 +253,14 @@ body.dark-mode #clock {
 }
 
 #mode-stats {
+  position: absolute;
+  top: 20px;
+  left: 0;
+  width: 100%;
   display: flex;
   justify-content: center;
   align-items: center;
   gap: 40px;
-  margin-top: 100px;
 }
 
 #mode-stats .stat-circle {
@@ -280,7 +283,7 @@ body.dark-mode #clock {
 
 #mode-buttons {
   position: fixed;
-  bottom: 135px;
+  bottom: 20px;
   left: 0;
   width: 100%;
   display: flex;
@@ -468,8 +471,12 @@ body.dark-mode #clock {
   font-family: 'Open Sans', sans-serif;
   font-size: 20px;
   font-weight: 700;
-  color: #fff;
+  color: #555;
   text-align: center;
+}
+
+body.dark-mode .circle-value {
+  color: #fff;
 }
 
 .circle-label {

--- a/index.html
+++ b/index.html
@@ -46,11 +46,11 @@
       <div id="general-speed-circle"></div>
     </div>
     <div id="texto-exibicao"></div>
-    <div id="pt-container">
-      <textarea id="pt" rows="1" readonly></textarea>
-    </div>
     <div id="barra-progresso">
       <div id="barra-preenchida"></div>
+    </div>
+    <div id="pt-container">
+      <textarea id="pt" rows="1" readonly></textarea>
     </div>
     <div id="nivel-mensagem"></div>
     <div id="timer"></div>

--- a/js/main.js
+++ b/js/main.js
@@ -689,25 +689,23 @@ function calcModeStats(mode) {
 
 function calcGeneralStats() {
   const modes = [2, 3, 4, 5, 6];
-  let totalPhrases = 0, totalCorrect = 0, totalTime = 0, totalReport = 0;
-  let timePercSum = 0, timePercCount = 0;
+  let accSum = 0, accCount = 0;
+  let timeSum = 0, timeCount = 0;
   modes.forEach(m => {
     const s = modeStats[m] || {};
-    totalPhrases += s.totalPhrases || 0;
-    totalCorrect += s.correct || 0;
-    totalTime += s.totalTime || 0;
-    totalReport += s.report || 0;
-    const tp = calcModeStats(m).timePerc;
-    if (tp >= 1) {
-      timePercSum += tp;
-      timePercCount++;
+    if (s.totalPhrases > 0) {
+      const stats = calcModeStats(m);
+      accSum += stats.accPerc;
+      accCount++;
+      if (stats.timePerc > 0) {
+        timeSum += stats.timePerc;
+        timeCount++;
+      }
     }
   });
-  const accPerc = totalPhrases ? (totalCorrect / totalPhrases * 100) : 0;
-  const avg = totalPhrases ? (totalTime / totalPhrases / 1000) : 0;
-  const timePerc = timePercCount ? (timePercSum / timePercCount) : 0;
-  const notReportPerc = totalPhrases ? (100 - (totalReport / totalPhrases * 100)) : 100;
-  return { accPerc, timePerc, avg, notReportPerc };
+  const accPerc = accCount ? (accSum / accCount) : 0;
+  const timePerc = timeCount ? (timeSum / timeCount) : 0;
+  return { accPerc, timePerc };
 }
 
 function updateGeneralCircles() {


### PR DESCRIPTION
## Summary
- Reposiciona marcadores gerais para o topo com ícone central
- Centraliza frase e barra de progresso; menu fixo ao rodapé
- Ajusta cálculo das médias gerais ignorando modos sem dados e estiliza gradientes/cores no modo claro

## Testing
- `npm test` *(falha: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688fe6456ea8832580ed5f1509aefeb9