### PR TITLE
Add time point metric support and modern custom styling

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -10,7 +10,7 @@ body.dark-mode {
 }
 
 body.custom-gradient {
-  background: linear-gradient(to bottom, #e0e0e0 0%, #ffffff 100%);
+  background: linear-gradient(135deg, #f5f5f5 0%, #ffffff 100%);
   color: #333;
 }
 

--- a/js/main.js
+++ b/js/main.js
@@ -190,7 +190,8 @@ function getTimeMetrics(len, mode) {
   if (!base) return { perfect: 0, worst: 0 };
   const [p6, w6] = base[6];
   const [p33, w33] = base[33];
-  const ratio = (len - 6) / (33 - 6);
+  const clampedLen = Math.max(1, len);
+  const ratio = (clampedLen - 6) / (33 - 6);
   const perfect = p6 + (p33 - p6) * ratio;
   const worst = w6 + (w33 - w6) * ratio;
   return { perfect, worst };
@@ -1284,7 +1285,7 @@ function verificarResposta() {
     ehQuaseCorreto(normalizadoResp, normalizadoEsp) ||
     ehQuaseCorretoPalavras(resposta, esperado);
 
-  const phraseLen = expectedPhrase.length;
+  const phraseLen = expectedPhrase.replace(/\s+/g, '').length;
   let timePoints = 0;
   if (selectedMode >= 2) {
     const { perfect, worst } = getTimeMetrics(phraseLen, selectedMode);


### PR DESCRIPTION
## Summary
- ensure time point metric handles very short phrases
- ignore whitespace when computing time-based scores
- refresh custom page background with a grey-to-white gradient

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6891b9a1ce708325b4fdbb5e153bc269