### PR TITLE
Adjust mobile microphone and layout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+package-lock.json

--- a/css/style.css
+++ b/css/style.css
@@ -3,6 +3,7 @@ body {
   background: linear-gradient(to bottom, #ffffff 0%, #f0f0f0 100%);
   font-family: 'Open Sans', sans-serif;
   --grad-color: #40e0d0;
+  overflow: hidden;
 }
 
 body.dark-mode {
@@ -77,7 +78,7 @@ body.dark-mode #intro-overlay {
   justify-content: center;
   gap: 20px;
   height: 100vh;
-  padding: 0 5vw 200px 5vw;
+  padding: 0 5vw 30px 5vw;
   display: none;
 }
 
@@ -188,6 +189,12 @@ body.dark-mode #clock {
   background-color: #ff0000;
   border-radius: 10px;
   transition: width 1.5s linear, background-color 1.5s linear;
+}
+
+#mode-stats,
+#texto-exibicao,
+#barra-progresso {
+  transform: translateY(-170px);
 }
 
 #resultado, #acertos {


### PR DESCRIPTION
## Summary
- Shift game HUD elements upward and remove vertical scrolling
- Delay mobile microphone activation until first phrase, disable at game end
- On mobile, trigger tutorial with triple tap on logo instead of auto-start

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6891ca0199208325bfcde5750e0e00f3