### PR TITLE
feat: add versus mode menu and bots

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -531,3 +531,31 @@ body.dark-mode #clock {
   color: lime;
 }
 
+#bot-list {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: 30px;
+  justify-content: center;
+  padding: 40px;
+}
+
+.bot-item {
+  text-align: center;
+  cursor: pointer;
+}
+
+.bot-item img {
+  width: 100px;
+  height: 100px;
+  border-radius: 50%;
+}
+
+#mode-list {
+  display: none;
+  grid-template-columns: repeat(3, 227px);
+  grid-auto-rows: 227px;
+  gap: 50px;
+  justify-content: center;
+  padding: 40px;
+}
+

--- a/custom.html
+++ b/custom.html
@@ -13,6 +13,7 @@
     <a href="#">fun</a>
     <a href="play.html">play</a>
     <a href="custom.html">custom</a>
+    <a href="versus.html">versus</a>
   </nav>
   <div id="custom-content" style="text-align:center;margin-top:50px;"></div>
   <script>

--- a/index.html
+++ b/index.html
@@ -18,6 +18,7 @@
     <a href="#">fun</a>
     <a href="play.html">play</a>
     <a href="custom.html">custom</a>
+    <a href="versus.html">versus</a>
   </nav>
     <div id="ilife-screen">
       <img id="ilife-logo" src="selos%20modos%20de%20jogo/logoitalk2.png" alt="Logo Italk">

--- a/js/versus.js
+++ b/js/versus.js
@@ -1,0 +1,31 @@
+document.addEventListener('DOMContentLoaded', () => {
+  fetch('users/bots.json')
+    .then(r => r.json())
+    .then(data => {
+      const list = document.getElementById('bot-list');
+      data.bots.forEach(bot => {
+        const div = document.createElement('div');
+        div.className = 'bot-item';
+        div.innerHTML = `<img src="users/${bot.file}" alt="${bot.name}"><div>${bot.name}</div>`;
+        div.addEventListener('click', () => showModes(bot));
+        list.appendChild(div);
+      });
+    });
+
+  function showModes(bot) {
+    document.getElementById('bot-list').style.display = 'none';
+    const modeList = document.getElementById('mode-list');
+    modeList.innerHTML = '';
+    for (let i = 2; i <= 6; i++) {
+      const img = document.createElement('img');
+      img.src = `selos%20modos%20de%20jogo/modo${i}.png`;
+      img.alt = `Modo ${i}`;
+      img.dataset.mode = i;
+      img.addEventListener('click', () => {
+        window.location.href = `play.html?mode=${i}&bot=${bot.name}`;
+      });
+      modeList.appendChild(img);
+    }
+    modeList.style.display = 'grid';
+  }
+});

--- a/play.html
+++ b/play.html
@@ -13,6 +13,7 @@
     <a href="#">fun</a>
     <a href="play.html">play</a>
     <a href="custom.html">custom</a>
+    <a href="versus.html">versus</a>
   </nav>
   <div id="play-content" style="text-align:center;margin-top:50px;"></div>
   <div id="mode-buttons">

--- a/users/bots.json
+++ b/users/bots.json
@@ -1,0 +1,70 @@
+{
+  "bots": [
+    {
+      "name": "Maya",
+      "file": "maya.png",
+      "modes": {
+        "2": {"precisao": 42, "tempo": 44},
+        "3": {"precisao": 44, "tempo": 41},
+        "4": {"precisao": 40, "tempo": 43},
+        "5": {"precisao": 41, "tempo": 40},
+        "6": {"precisao": 39, "tempo": 42}
+      }
+    },
+    {
+      "name": "Charlotte",
+      "file": "charlotte.png",
+      "modes": {
+        "2": {"precisao": 56, "tempo": 58},
+        "3": {"precisao": 58, "tempo": 56},
+        "4": {"precisao": 55, "tempo": 57},
+        "5": {"precisao": 57, "tempo": 59},
+        "6": {"precisao": 54, "tempo": 55}
+      }
+    },
+    {
+      "name": "Bella",
+      "file": "bella.png",
+      "modes": {
+        "2": {"precisao": 72, "tempo": 74},
+        "3": {"precisao": 75, "tempo": 73},
+        "4": {"precisao": 70, "tempo": 71},
+        "5": {"precisao": 68, "tempo": 69},
+        "6": {"precisao": 71, "tempo": 72}
+      }
+    },
+    {
+      "name": "Jimmy",
+      "file": "jimmy.png",
+      "modes": {
+        "2": {"precisao": 82, "tempo": 83},
+        "3": {"precisao": 84, "tempo": 85},
+        "4": {"precisao": 81, "tempo": 82},
+        "5": {"precisao": 80, "tempo": 81},
+        "6": {"precisao": 83, "tempo": 84}
+      }
+    },
+    {
+      "name": "Willy",
+      "file": "willy.png",
+      "modes": {
+        "2": {"precisao": 92, "tempo": 91},
+        "3": {"precisao": 91, "tempo": 92},
+        "4": {"precisao": 89, "tempo": 90},
+        "5": {"precisao": 87, "tempo": 88},
+        "6": {"precisao": 90, "tempo": 89}
+      }
+    },
+    {
+      "name": "Bit",
+      "file": "bit.png",
+      "modes": {
+        "2": {"precisao": 100, "tempo": 100},
+        "3": {"precisao": 99, "tempo": 100},
+        "4": {"precisao": 97, "tempo": 98},
+        "5": {"precisao": 98, "tempo": 99},
+        "6": {"precisao": 100, "tempo": 100}
+      }
+    }
+  ]
+}

--- a/versus.html
+++ b/versus.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Versus</title>
+  <link href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@400;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="css/style.css">
+</head>
+<body class="dark-mode">
+  <nav id="top-nav">
+    <a href="index.html">home</a>
+    <a href="#">fun</a>
+    <a href="play.html">play</a>
+    <a href="custom.html">custom</a>
+    <a href="versus.html">versus</a>
+  </nav>
+  <div id="bot-list"></div>
+  <div id="mode-list"></div>
+  <script src="js/versus.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add Versus to top navigation and create Versus selection page
- introduce bot metadata for Versus mode and basic grid styles
- load bot list from JSON and allow mode selection

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6891e204a9e48325a411db5b30fa898e