### PR TITLE
feat: simulate versus bots with round metrics

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -533,7 +533,8 @@ body.dark-mode #clock {
 
 #bot-list {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  grid-template-columns: repeat(3, 150px);
+  grid-auto-rows: 150px;
   gap: 30px;
   justify-content: center;
   padding: 40px;
@@ -545,17 +546,29 @@ body.dark-mode #clock {
 }
 
 .bot-item img {
-  width: 100px;
-  height: 100px;
+  width: 150px;
+  height: 150px;
   border-radius: 50%;
 }
 
 #mode-list {
   display: none;
-  grid-template-columns: repeat(3, 227px);
-  grid-auto-rows: 227px;
-  gap: 50px;
+  grid-template-columns: repeat(3, 117px);
+  grid-auto-rows: 117px;
+  gap: 30px;
   justify-content: center;
   padding: 40px;
+}
+
+#mode-list img {
+  width: 117px;
+  height: 117px;
+  cursor: pointer;
+  opacity: 0.35;
+  transition: opacity 0.2s linear;
+}
+
+#mode-list img:hover {
+  opacity: 1;
 }
 

--- a/play.html
+++ b/play.html
@@ -16,6 +16,14 @@
     <a href="versus.html">versus</a>
   </nav>
   <div id="play-content" style="text-align:center;margin-top:50px;"></div>
+  <div id="versus-stats" style="display:none;text-align:center;margin-top:50px;">
+    <h2 id="vs-title"></h2>
+    <div id="round"></div>
+    <div id="user-acc"></div>
+    <div id="user-time"></div>
+    <div id="bot-acc"></div>
+    <div id="bot-time"></div>
+  </div>
   <div id="mode-buttons">
     <img src="selos%20modos%20de%20jogo/modo1.png" data-mode="1" class="mode-btn" alt="Modo 1" />
     <img src="selos%20modos%20de%20jogo/modo2.png" data-mode="2" class="mode-btn" alt="Modo 2" />


### PR DESCRIPTION
## Summary
- enlarge versus bot icons and adjust mode selection layout
- add versus stats section and bot simulation
- track round metrics with 7% variation for bots

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6891e5a2c59883259275ef5cceb3c60f