### PR TITLE
Implement basic versus match mode

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -572,3 +572,90 @@ body.dark-mode #clock {
   opacity: 1;
 }
 
+
+#versus-arena {
+  display: flex;
+  justify-content: center;
+  align-items: flex-start;
+  gap: 0;
+  margin-top: 40px;
+}
+
+.player-block {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  font-family: 'Open Sans', sans-serif;
+}
+
+#user-block { margin-right: 100px; }
+#opponent-block { margin-left: 100px; }
+
+.player-name {
+  font-size: 20px;
+  margin-bottom: 10px;
+}
+
+.player-avatar {
+  width: 120px;
+  height: 120px;
+  object-fit: contain;
+  margin-bottom: 10px;
+}
+
+.player-stats .stat-bar {
+  width: 200px;
+  height: 25px;
+  background: #ddd;
+  position: relative;
+}
+
+.stat-bar .stat-fill {
+  height: 100%;
+  width: 0%;
+  background: #ff0000;
+  transition: width 0.3s linear, background-color 0.3s linear, opacity 0.3s;
+}
+
+#center-area {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-width: 200px;
+}
+
+#phrase {
+  font-size: 24px;
+  margin-bottom: 20px;
+  text-align: center;
+}
+
+#user-input {
+  width: 300px;
+  height: 40px;
+  font-size: 18px;
+  text-align: center;
+}
+
+#match-progress {
+  width: 80%;
+  height: 20px;
+  background: #ddd;
+  margin: 40px auto 0 auto;
+}
+
+#match-progress-fill {
+  height: 100%;
+  width: 0%;
+  background: #ff0000;
+  transition: width 1s linear, background-color 1s linear;
+}
+
+#match-timer {
+  text-align: center;
+  margin-top: 10px;
+  font-size: 20px;
+  font-family: 'Open Sans', sans-serif;
+}
+

--- a/js/versus.js
+++ b/js/versus.js
@@ -22,7 +22,7 @@ document.addEventListener('DOMContentLoaded', () => {
       img.alt = `Modo ${i}`;
       img.dataset.mode = i;
       img.addEventListener('click', () => {
-        window.location.href = `play.html?mode=${i}&bot=${bot.name}`;
+        window.location.href = `versusplay.html?mode=${i}&bot=${bot.name}`;
       });
       modeList.appendChild(img);
     }

--- a/js/versusplay.js
+++ b/js/versusplay.js
@@ -1,0 +1,175 @@
+const colorStops = [
+  [0, '#ff0000'],
+  [2000, '#ff3b00'],
+  [4000, '#ff7f00'],
+  [6000, '#ffb300'],
+  [8000, '#ffe000'],
+  [10000, '#ffff66'],
+  [12000, '#ccff66'],
+  [14000, '#99ff99'],
+  [16000, '#00cc66'],
+  [18000, '#00994d'],
+  [20000, '#00ffff'],
+  [22000, '#66ccff'],
+  [24000, '#0099ff'],
+  [25000, '#0099ff']
+];
+
+function hexToRgb(hex) {
+  const int = parseInt(hex.slice(1), 16);
+  return [int >> 16 & 255, int >> 8 & 255, int & 255];
+}
+
+function rgbToHex(r, g, b) {
+  return '#' + [r, g, b].map(x => x.toString(16).padStart(2, '0')).join('');
+}
+
+function calcularCor(pontos) {
+  const max = colorStops[colorStops.length - 1][0];
+  const p = Math.max(0, Math.min(pontos, max));
+  for (let i = 0; i < colorStops.length - 1; i++) {
+    const [p1, c1] = colorStops[i];
+    const [p2, c2] = colorStops[i + 1];
+    if (p >= p1 && p <= p2) {
+      const ratio = (p - p1) / (p2 - p1);
+      const [r1, g1, b1] = hexToRgb(c1);
+      const [r2, g2, b2] = hexToRgb(c2);
+      const r = Math.round(r1 + ratio * (r2 - r1));
+      const g = Math.round(g1 + ratio * (g2 - g1));
+      const b = Math.round(b1 + ratio * (b2 - b1));
+      return rgbToHex(r, g, b);
+    }
+  }
+  return colorStops[colorStops.length - 1][1];
+}
+
+function colorFromPercent(perc) {
+  const max = colorStops[colorStops.length - 1][0];
+  return calcularCor((perc / 100) * max);
+}
+
+function parsePastas(raw) {
+  const result = {};
+  for (const [key, texto] of Object.entries(raw)) {
+    result[key] = texto.trim().split(/\n+/).filter(Boolean).map(l => l.split('#').map(s => s.trim()));
+  }
+  return result;
+}
+
+async function carregarFrases() {
+  const resp = await fetch('data/pastas.json');
+  const text = await resp.text();
+  const obj = {};
+  const regex = /(\d+):\s*`([\s\S]*?)`/g;
+  let m;
+  while ((m = regex.exec(text))) {
+    obj[m[1]] = m[2];
+  }
+  const pastas = parsePastas(obj);
+  const todas = [];
+  Object.values(pastas).forEach(arr => {
+    arr.forEach(p => {
+      if (p[1] && p[1].length <= 24) todas.push(p);
+    });
+  });
+  return todas;
+}
+
+function setBar(id, perc) {
+  const bar = document.getElementById(id);
+  bar.style.opacity = 0;
+  setTimeout(() => {
+    bar.style.width = Math.min(perc, 100) + '%';
+    bar.style.backgroundColor = colorFromPercent(perc);
+    bar.style.opacity = 1;
+  }, 50);
+}
+
+document.addEventListener('DOMContentLoaded', async () => {
+  const params = new URLSearchParams(window.location.search);
+  const botName = params.get('bot');
+  const mode = parseInt(params.get('mode'), 10) || 2;
+
+  const botData = await fetch('users/bots.json').then(r => r.json());
+  const bot = botData.bots.find(b => b.name === botName) || botData.bots[0];
+  document.getElementById('opponent-name').textContent = bot.name;
+  document.getElementById('opponent-avatar').src = 'users/' + bot.file;
+
+  const frases = await carregarFrases();
+  let atual = null;
+  let inicio = 0;
+  const entrada = document.getElementById('user-input');
+  const fraseEl = document.getElementById('phrase');
+
+  const stats = {
+    user: { correct: 0, total: 0, time: 0 },
+    bot: { correct: 0, total: 0, time: 0 }
+  };
+
+  function novaFrase() {
+    atual = frases[Math.floor(Math.random() * frases.length)];
+    fraseEl.textContent = atual[0];
+    entrada.value = '';
+    inicio = Date.now();
+    entrada.focus();
+  }
+
+  function simularBot() {
+    const base = bot.modes[String(mode)] || { precisao: 50, tempo: 50 };
+    const correto = Math.random() < base.precisao / 100;
+    const tempo = base.tempo / 20 + (Math.random() - 0.5) * 0.4;
+    stats.bot.total++;
+    stats.bot.time += tempo;
+    if (correto) stats.bot.correct++;
+  }
+
+  entrada.addEventListener('keydown', e => {
+    if (e.key === 'Enter' && atual) {
+      const decorrido = (Date.now() - inicio) / 1000;
+      stats.user.total++;
+      stats.user.time += decorrido;
+      if (entrada.value.trim().toLowerCase() === atual[1].toLowerCase()) {
+        stats.user.correct++;
+      }
+      simularBot();
+      novaFrase();
+    }
+  });
+
+  function atualizarBarras() {
+    const uAvg = stats.user.total ? stats.user.time / stats.user.total : 0;
+    const uAcc = stats.user.total ? stats.user.correct / stats.user.total * 100 : 0;
+    const bAvg = stats.bot.total ? stats.bot.time / stats.bot.total : 0;
+    const bAcc = stats.bot.total ? stats.bot.correct / stats.bot.total * 100 : 0;
+    setBar('user-time-bar', uAvg * 10);
+    setBar('user-acc-bar', uAcc);
+    setBar('bot-time-bar', bAvg * 10);
+    setBar('bot-acc-bar', bAcc);
+  }
+
+  novaFrase();
+  atualizarBarras();
+  setInterval(atualizarBarras, 10000);
+
+  const duracao = 120000;
+  const inicioJogo = Date.now();
+  const barra = document.getElementById('match-progress-fill');
+  const timerEl = document.getElementById('match-timer');
+
+  const timer = setInterval(() => {
+    const decorrido = Date.now() - inicioJogo;
+    const restante = duracao - decorrido;
+    if (restante <= 0) {
+      clearInterval(timer);
+      barra.style.width = '100%';
+      timerEl.textContent = '0s';
+      entrada.disabled = true;
+      fraseEl.textContent = 'Fim!';
+      return;
+    }
+    const perc = decorrido / duracao * 100;
+    barra.style.width = perc + '%';
+    barra.style.backgroundColor = colorFromPercent(100 - perc);
+    timerEl.textContent = Math.ceil(restante / 1000) + 's';
+  }, 1000);
+});

--- a/versusplay.html
+++ b/versusplay.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Versus Match</title>
+  <link href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@400;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="css/style.css">
+</head>
+<body class="dark-mode">
+  <nav id="top-nav">
+    <a href="index.html">home</a>
+    <a href="#">fun</a>
+    <a href="play.html">play</a>
+    <a href="custom.html">custom</a>
+    <a href="versus.html">versus</a>
+  </nav>
+  <div id="versus-arena">
+    <div class="player-block" id="user-block">
+      <div class="player-name" id="user-name">the user</div>
+      <img class="player-avatar" id="user-avatar" src="users/theuser.png" alt="the user">
+      <div class="player-stats">
+        <div class="stat-bar"><div class="stat-fill" id="user-time-bar"></div></div>
+        <div class="stat-bar" style="margin-top:15px"><div class="stat-fill" id="user-acc-bar"></div></div>
+      </div>
+    </div>
+    <div id="center-area">
+      <div id="phrase"></div>
+      <input type="text" id="user-input" autocomplete="off" />
+    </div>
+    <div class="player-block" id="opponent-block">
+      <div class="player-name" id="opponent-name"></div>
+      <img class="player-avatar" id="opponent-avatar" alt="opponent">
+      <div class="player-stats">
+        <div class="stat-bar"><div class="stat-fill" id="bot-time-bar"></div></div>
+        <div class="stat-bar" style="margin-top:15px"><div class="stat-fill" id="bot-acc-bar"></div></div>
+      </div>
+    </div>
+  </div>
+  <div id="match-progress"><div id="match-progress-fill"></div></div>
+  <div id="match-timer"></div>
+  <script src="js/versusplay.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Create dedicated versus match page with player avatars, stat bars, timer and progress bar
- Load 2-minute matches with phrases (≤24 chars) and update time/accuracy every 10s
- Link versus menu to new match page and add necessary styles

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6891ec8858808325abaefe64640aa64b