### PR TITLE
Enable voice-only Versus mode with short English prompts

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -629,7 +629,7 @@ body.dark-mode #clock {
 
 #versus-game #barra-progresso {
   width: 500px;
-  margin: 20px auto 0;
+  margin: 60px auto 0;
 }
 
 @media (max-width: 600px) {
@@ -639,11 +639,5 @@ body.dark-mode #clock {
   #versus-game #barra-progresso {
     width: 90%;
   }
-}
-
-#versus-input {
-  margin-top: 20px;
-  padding: 10px;
-  font-size: 18px;
 }
 

--- a/js/versus.js
+++ b/js/versus.js
@@ -99,21 +99,36 @@ document.addEventListener('DOMContentLoaded', () => {
   let botAccPerc = 0;
   let progressTimer = null;
   let updateTimer = null;
+  let reconhecimento = null;
+  let modoAtual = 0;
 
-  const input = document.getElementById('versus-input');
   const fraseEl = document.getElementById('versus-phrase');
   const userImg = document.querySelector('#player-user .player-img');
   const botImg = document.getElementById('bot-avatar');
 
-  input.addEventListener('keypress', e => {
-    if (e.key === 'Enter') verificar();
-  });
+  if ('webkitSpeechRecognition' in window || 'SpeechRecognition' in window) {
+    const SpeechRecognition = window.SpeechRecognition || window.webkitSpeechRecognition;
+    reconhecimento = new SpeechRecognition();
+    reconhecimento.lang = 'en-US';
+    reconhecimento.continuous = true;
+    reconhecimento.interimResults = false;
+    reconhecimento.onresult = (e) => {
+      const transcript = e.results[e.results.length - 1][0].transcript.trim().toLowerCase();
+      verificar(transcript);
+    };
+    reconhecimento.onerror = (e) => console.error('Erro no reconhecimento de voz:', e.error);
+    reconhecimento.onend = () => {
+      if (modoAtual) try { reconhecimento.start(); } catch (err) {}
+    };
+  } else {
+    alert('Reconhecimento de voz não suportado.');
+  }
 
   function showModes(bot) {
     document.getElementById('bot-list').style.display = 'none';
     const modeList = document.getElementById('mode-list');
     modeList.innerHTML = '';
-    for (let i = 2; i <= 6; i++) {
+    for (let i = 1; i <= 6; i++) {
       const img = document.createElement('img');
       img.src = `selos%20modos%20de%20jogo/modo${i}.png`;
       img.alt = `Modo ${i}`;
@@ -126,12 +141,13 @@ document.addEventListener('DOMContentLoaded', () => {
 
   async function startVersus(bot, modo) {
     botAtual = bot;
+    modoAtual = modo;
     document.getElementById('mode-list').style.display = 'none';
     const game = document.getElementById('versus-game');
     document.getElementById('bot-name').textContent = bot.name;
     botImg.src = `users/${bot.file}`;
     game.style.display = 'block';
-    frases = Object.values(await carregarPastas()).flat();
+    frases = Object.values(await carregarPastas()).flat().filter(([, en]) => en.length <= 15);
     frases = embaralhar(frases);
     botStats = bot.modes[String(modo)] || { precisao: 0, tempo: 0 };
     nextFrase();
@@ -139,6 +155,7 @@ document.addEventListener('DOMContentLoaded', () => {
     updateBars();
     updateTimer = setInterval(updateBars, 10000);
     setTimeout(encerrar, 120000);
+    if (reconhecimento) try { reconhecimento.start(); } catch (err) {}
   }
 
   function embaralhar(arr) {
@@ -152,19 +169,22 @@ document.addEventListener('DOMContentLoaded', () => {
   function nextFrase() {
     if (fraseIndex >= frases.length) fraseIndex = 0;
     const [pt, en] = frases[fraseIndex];
-    fraseEl.textContent = pt;
-    esperado = en.toLowerCase();
+    if (modoAtual === 1) {
+      fraseEl.textContent = en;
+      esperado = en.toLowerCase();
+    } else {
+      fraseEl.textContent = pt;
+      esperado = en.toLowerCase();
+    }
     inicioFrase = Date.now();
     fraseIndex++;
   }
 
-  function verificar() {
-    const resp = input.value.trim().toLowerCase();
+  function verificar(resp) {
     const tempo = Date.now() - inicioFrase;
     totalTempo += tempo;
     totalFrases++;
     if (resp === esperado) acertos++;
-    input.value = '';
     nextFrase();
   }
 
@@ -205,7 +225,8 @@ document.addEventListener('DOMContentLoaded', () => {
     clearInterval(updateTimer);
     fraseEl.style.transition = 'opacity 0.5s';
     fraseEl.style.opacity = 0;
-    input.style.display = 'none';
+    modoAtual = 0;
+    if (reconhecimento) try { reconhecimento.stop(); } catch (err) {}
     const userScore = (userAccPerc + userTimePerc) / 2;
     const botScore = (botAccPerc + botTimePerc) / 2;
     if (userScore > botScore) {

--- a/versus.html
+++ b/versus.html
@@ -34,7 +34,6 @@
     </div>
     <div id="versus-phrase"></div>
     <div id="barra-progresso"><div id="barra-preenchida"></div></div>
-    <input id="versus-input" maxlength="24" autocomplete="off" />
   </div>
   <script src="js/versus.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- Replace text input in Versus mode with speech recognition and reposition the timer progress bar
- Allow selecting Mode 1, showing English phrases and filtering prompts to ≤15 characters
- Randomly pull short phrases from all JSON folders and compare spoken answers only

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6891fabbb02883258c30f5ff82c8a0a1