### PR TITLE
Implement mobile reading tweaks and disable scrolling

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -667,3 +667,23 @@ body.dark-mode #clock {
   }
 }
 
+/* Mobile reading mode adjustments */
+.title-box {
+  background-color: rgba(0, 0, 0, 0);
+}
+
+.text-block {
+  margin: 0 20px;
+  text-align: justify;
+  text-wrap: balance;
+}
+
+@media (max-width: 600px) {
+  .title-box {
+    transform: translateY(30px);
+  }
+  .chapter-text {
+    font-family: 'Bookerly', var(--reader-font, serif);
+  }
+}
+

--- a/custom.html
+++ b/custom.html
@@ -16,6 +16,7 @@
     <a href="versus.html">versus</a>
   </nav>
   <div id="custom-content" style="text-align:center;margin-top:50px;"></div>
+  <script src="js/disableScroll.js"></script>
   <script>
     function formatTime(ms) {
       const sec = Math.floor(ms / 1000);

--- a/index.html
+++ b/index.html
@@ -96,6 +96,7 @@
   <audio id="somLock" src="gamesounds/lock.wav"></audio>
   <audio id="somLevelStar" src="gamesounds/levelstar.mp3"></audio>
 
+  <script src="js/disableScroll.js"></script>
   <script src="js/main.js"></script>
 </body>
 </html>

--- a/js/disableScroll.js
+++ b/js/disableScroll.js
@@ -1,0 +1,13 @@
+(function() {
+  if (/Mobi|Android/i.test(navigator.userAgent)) {
+    const path = window.location.pathname || '';
+    if (!path.includes('livros')) {
+      document.body.style.overflow = 'hidden';
+      const prevent = e => e.preventDefault();
+      document.addEventListener('touchmove', prevent, { passive: false });
+      document.addEventListener('wheel', prevent, { passive: false });
+    } else {
+      document.body.style.overflow = 'auto';
+    }
+  }
+})();

--- a/js/versus.js
+++ b/js/versus.js
@@ -167,6 +167,25 @@ document.addEventListener('DOMContentLoaded', () => {
     return arr;
   }
 
+  function balanceText(el) {
+    const text = el.textContent.trim();
+    const words = text.split(/\s+/);
+    const targetLen = Math.ceil(text.length / 3);
+    const lines = [];
+    let current = '';
+    words.forEach(word => {
+      const next = current ? current + ' ' + word : word;
+      if (next.length <= targetLen || !current) {
+        current = next;
+      } else {
+        lines.push(current);
+        current = word;
+      }
+    });
+    if (current) lines.push(current);
+    el.innerHTML = lines.join('<br>');
+  }
+
   function nextFrase() {
     if (fraseIndex >= frases.length) fraseIndex = 0;
     const [pt, en] = frases[fraseIndex];
@@ -175,6 +194,7 @@ document.addEventListener('DOMContentLoaded', () => {
     fraseEl.style.fontSize = '40px';
     fraseEl.style.color = '#fff';
     fraseEl.textContent = pt;
+    balanceText(fraseEl);
     esperado = en.toLowerCase();
     if (modoAtual === 5) {
       const utter = new SpeechSynthesisUtterance(en);

--- a/play.html
+++ b/play.html
@@ -32,6 +32,7 @@
     <img src="selos%20modos%20de%20jogo/modo5.png" data-mode="5" class="mode-btn" alt="Modo 5" />
     <img src="selos%20modos%20de%20jogo/modo6.png" data-mode="6" class="mode-btn" alt="Modo 6" />
   </div>
+  <script src="js/disableScroll.js"></script>
   <script src="js/play.js"></script>
 </body>
 </html>

--- a/versus.html
+++ b/versus.html
@@ -32,9 +32,11 @@
         <div class="stat-bar acc"><div class="fill"></div></div>
       </div>
     </div>
-    <div id="versus-phrase"></div>
+    <div class="title-box"><div id="chapter-title" class="chapter-text">Capítulo</div></div>
+    <div id="versus-phrase" class="text-block"></div>
     <div id="barra-progresso"><div id="barra-preenchida"></div></div>
   </div>
+  <script src="js/disableScroll.js"></script>
   <script src="js/versus.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Add CSS utilities for mobile reading with a transparent title box, balanced text blocks, and Bookerly chapter font
- Inject a scroll-prevention script across pages to disable vertical scrolling on mobile except for the "livros" page
- Balance verse display by splitting text into similar-length lines during versus gameplay

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6895b19f317483259a99a8cb1752d2eb