### PR TITLE
Refine play layout and adjust mode behaviors

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -328,11 +328,33 @@ body.dark-mode #clock {
   transition: opacity 0.2s linear;
 }
 
+body.play-page #mode-buttons {
+  bottom: 70px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: auto;
+  display: grid;
+  grid-template-columns: repeat(3, 75px);
+  grid-template-rows: repeat(2, 75px);
+  gap: 20px;
+  justify-content: center;
+}
+
+body.play-page #mode-buttons img {
+  width: 75px;
+  height: 75px;
+}
+
 #play-content {
   display: flex;
   justify-content: center;
   align-items: center;
   gap: 40px;
+}
+
+body.play-page #play-content {
+  flex-direction: column;
+  gap: 20px;
 }
 
 @media (max-width: 600px) {

--- a/index.html
+++ b/index.html
@@ -42,9 +42,7 @@
     <!-- conteúdo visual aqui -->
     <div id="score"></div>
     <div id="mode-stats">
-      <div id="general-score-circle"></div>
       <img id="mode-icon" alt="Mode Icon" style="display:none" />
-      <div id="general-speed-circle"></div>
     </div>
     <div id="texto-exibicao"></div>
     <div id="barra-progresso">

--- a/js/main.js
+++ b/js/main.js
@@ -366,7 +366,6 @@ function saveModeStats() {
   if (typeof saveUserPerformance === 'function') {
     saveUserPerformance(modeStats);
   }
-  updateGeneralCircles();
 }
 
 function saveTotals() {
@@ -720,110 +719,6 @@ function colorFromPercent(perc) {
   return calcularCor((perc / 100) * max);
 }
 
-function createStatCircle(perc, label, iconSrc, extraText) {
-  const wrapper = document.createElement('div');
-  wrapper.className = 'stat-circle';
-  const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
-  svg.setAttribute('viewBox', '0 0 120 120');
-  const radius = 38;
-  const circumference = 2 * Math.PI * radius;
-  const bg = document.createElementNS('http://www.w3.org/2000/svg', 'circle');
-  bg.setAttribute('class', 'circle-bg');
-  bg.setAttribute('cx', '60');
-  bg.setAttribute('cy', '60');
-  bg.setAttribute('r', radius);
-  svg.appendChild(bg);
-  const prog = document.createElementNS('http://www.w3.org/2000/svg', 'circle');
-  prog.setAttribute('class', 'circle-progress');
-  prog.setAttribute('cx', '60');
-  prog.setAttribute('cy', '60');
-  prog.setAttribute('r', radius);
-  prog.setAttribute('stroke-dasharray', circumference);
-  const clamped = Math.max(0, Math.min(perc, 100));
-  prog.setAttribute('stroke-dashoffset', circumference);
-  prog.style.stroke = colorFromPercent(perc);
-  svg.appendChild(prog);
-  wrapper.appendChild(svg);
-  const icon = document.createElement('img');
-  icon.className = 'circle-icon';
-  icon.src = iconSrc;
-  icon.alt = label;
-  wrapper.appendChild(icon);
-  setTimeout(() => {
-    prog.setAttribute('stroke-dashoffset', circumference * (1 - clamped / 100));
-  }, 50);
-  const value = document.createElement('div');
-  value.className = 'circle-value';
-  value.textContent = `${Math.round(perc)}%`;
-  wrapper.appendChild(value);
-  const labelEl = document.createElement('div');
-  labelEl.className = 'circle-label';
-  labelEl.textContent = label;
-  wrapper.appendChild(labelEl);
-  if (extraText) {
-    const extra = document.createElement('div');
-    extra.className = 'circle-extra';
-    extra.textContent = extraText;
-    wrapper.appendChild(extra);
-  }
-  return wrapper;
-}
-
-function calcModeStats(mode) {
-  const stats = modeStats[mode] || {};
-  const total = stats.totalPhrases || 0;
-  const correct = stats.correct || 0;
-  const report = stats.report || 0;
-  const totalTime = stats.totalTime || 0;
-  const timePts = stats.timePoints || 0;
-  const accPerc = total ? (correct / total * 100) : 0;
-  const avg = total ? (totalTime / total / 1000) : 0;
-  const timePerc = total ? (timePts / total) : 0;
-  const notReportPerc = total ? (100 - (report / total * 100)) : 100;
-  return { accPerc, timePerc, avg, notReportPerc };
-}
-
-function calcGeneralStats() {
-  const modes = [2, 3, 4, 5, 6];
-  let totalPhrases = 0, totalCorrect = 0, totalTime = 0, totalReport = 0;
-  let timePercSum = 0, timePercCount = 0;
-  modes.forEach(m => {
-    const s = modeStats[m] || {};
-    totalPhrases += s.totalPhrases || 0;
-    totalCorrect += s.correct || 0;
-    totalTime += s.totalTime || 0;
-    totalReport += s.report || 0;
-    const tp = calcModeStats(m).timePerc;
-    if (tp >= 1) {
-      timePercSum += tp;
-      timePercCount++;
-    }
-  });
-  const accPerc = totalPhrases ? (totalCorrect / totalPhrases * 100) : 0;
-  const avg = totalPhrases ? (totalTime / totalPhrases / 1000) : 0;
-  const timePerc = timePercCount ? (timePercSum / timePercCount) : 0;
-  const notReportPerc = totalPhrases ? (100 - (totalReport / totalPhrases * 100)) : 100;
-  return { accPerc, timePerc, avg, notReportPerc };
-}
-
-function updateGeneralCircles() {
-  const { accPerc, timePerc } = calcGeneralStats();
-  const scoreWrapper = document.getElementById('general-score-circle');
-  const speedWrapper = document.getElementById('general-speed-circle');
-  if (scoreWrapper) {
-    scoreWrapper.innerHTML = '';
-    scoreWrapper.appendChild(
-      createStatCircle(accPerc, 'Pontuação Geral', 'selos%20modos%20de%20jogo/precisao.png')
-    );
-  }
-  if (speedWrapper) {
-    speedWrapper.innerHTML = '';
-    speedWrapper.appendChild(
-      createStatCircle(timePerc, 'Velocidade Geral', 'selos%20modos%20de%20jogo/velocidade.png')
-    );
-  }
-}
-
 let introProgressInterval = null;
 
 function startIntroProgress(duration) {
@@ -1100,16 +995,15 @@ function beginGame() {
       icon.style.display = 'block';
       icon.onclick = () => { if (paused) resumeGame(); };
     }
-    updateGeneralCircles();
     const texto = document.getElementById('texto-exibicao');
     if (texto) texto.style.opacity = '1';
     updateLevelIcon();
     updateModeIcons();
     switch (selectedMode) {
       case 1:
-        mostrarTexto = 'pt';
+        mostrarTexto = 'en';
         voz = 'en';
-        esperadoLang = 'pt';
+        esperadoLang = 'en';
         break;
     case 2:
       mostrarTexto = 'pt';
@@ -1127,9 +1021,9 @@ function beginGame() {
       esperadoLang = 'en';
       break;
     case 5:
-      mostrarTexto = 'none';
-      voz = 'en';
-      esperadoLang = 'pt';
+      mostrarTexto = 'pt';
+      voz = null;
+      esperadoLang = 'en';
       break;
     case 6:
       mostrarTexto = 'pt';

--- a/play.html
+++ b/play.html
@@ -7,7 +7,7 @@
   <link href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@400;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="css/style.css">
 </head>
-<body class="dark-mode">
+<body class="dark-mode play-page">
   <nav id="top-nav">
     <a href="index.html">home</a>
     <a href="#">fun</a>


### PR DESCRIPTION
## Summary
- Remove desktop time/accuracy metrics and their icons from the game UI
- Stack stats vertically and grid mode icons in play page for clearer layout
- Update modes: Mode 1 uses English text and speech, Mode 5 shows Portuguese text, expects English without synthetic voice

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68989d9c681c8325a993b67ce61fc7da