### PR TITLE
Normalize homophones before answer checking

### DIFF
--- a/data/homophones.txt
+++ b/data/homophones.txt
@@ -1,0 +1,6 @@
+hear@here@heir
+flower@flour
+pair@pear@pare
+to@too@two
+see@sea
+buy@by@bye


### PR DESCRIPTION
## Summary
- Add homophones list and loader that builds a canonical word map
- Normalize player and expected phrases using the homophone map before comparison

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689aa8a0d24483258711c54989578c80