### PR TITLE
refactor: remove animations and adjust opacity

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -124,8 +124,7 @@ body.dark-mode #clock {
   height: 227px;
   object-fit: contain;
   cursor: pointer;
-  opacity: 0.3;
-  transition: opacity 0.2s linear;
+  opacity: 0.5;
 }
 
 
@@ -188,7 +187,6 @@ body.dark-mode #clock {
   width: 0%;
   background-color: #ff0000;
   border-radius: 10px;
-  transition: width 1.5s linear, background-color 1.5s linear;
 }
 
 #mode-stats,
@@ -306,7 +304,6 @@ body.dark-mode #clock {
   height: 250px;
   opacity: 0;
   pointer-events: none;
-  transition: opacity 500ms linear;
 }
 
 #mode-buttons {
@@ -324,8 +321,7 @@ body.dark-mode #clock {
   width: 117px;
   height: 117px;
   cursor: pointer;
-  opacity: 0.35;
-  transition: opacity 0.2s linear;
+  opacity: 0.5;
 }
 
 body.play-page #mode-buttons {
@@ -343,6 +339,7 @@ body.play-page #mode-buttons {
 body.play-page #mode-buttons img {
   width: 75px;
   height: 75px;
+  opacity: 0.5;
 }
 
 #play-content {
@@ -378,15 +375,6 @@ body.play-page #play-content {
   }
 }
 
-@keyframes mode1Zoom {
-  from { transform: scale(0.8); }
-  to { transform: scale(1); }
-}
-
-@keyframes modeZoom {
-  from { transform: scale(0.8); }
-  to { transform: scale(1); }
-}
 
 #logo-top {
   position: absolute;
@@ -427,8 +415,7 @@ body.play-page #play-content {
 #ilife-logo {
   width: 20%;
   height: auto;
-  opacity: 0;
-  animation: fadeIn 1000ms forwards;
+  opacity: 1;
 }
 
 #ilife-text {
@@ -447,13 +434,9 @@ body.play-page #play-content {
   font-size: 14px;
   color: #777;
   opacity: 0;
-  transition: opacity 500ms linear;
 }
 
-@keyframes fadeIn {
-  from { opacity: 0; }
-  to { opacity: 1; }
-}
+
 
 /* Play stats page */
 .mode-section {
@@ -496,14 +479,13 @@ body.play-page #play-content {
   fill: none;
   stroke: #444;
   stroke-width: 9.75;
-  opacity: 0.3;
+  opacity: 0.5;
 }
 
 .circle-progress {
   fill: none;
   stroke-width: 9.75;
   stroke-linecap: butt;
-  transition: stroke-dashoffset 1s;
 }
 
 .circle-icon {
@@ -585,6 +567,7 @@ body.play-page #play-content {
   width: 150px;
   height: 150px;
   border-radius: 50%;
+  opacity: 0.5;
 }
 
 #mode-list {
@@ -600,8 +583,7 @@ body.play-page #play-content {
   width: 117px;
   height: 117px;
   cursor: pointer;
-  opacity: 0.35;
-  transition: opacity 0.2s linear;
+  opacity: 0.5;
 }
 
 #mode-list img:hover {
@@ -632,6 +614,7 @@ body.play-page #play-content {
   width: 120px;
   height: 120px;
   object-fit: cover;
+  opacity: 0.5;
 }
 
 .stat-bar {
@@ -651,7 +634,6 @@ body.play-page #play-content {
   width: 0;
   background: #ff0000;
   opacity: 1;
-  transition: width 0.5s linear, background-color 0.5s linear, opacity 0.3s;
 }
 
 #versus-phrase {
@@ -677,7 +659,6 @@ body.play-page #play-content {
   height: 100%;
   width: 0;
   background-color: #ff0000;
-  transition: width 0.1s linear, background-color 0.1s linear;
 }
 
 @media (max-width: 600px) {
@@ -706,6 +687,30 @@ body.play-page #play-content {
   }
   .chapter-text {
     font-family: 'Bookerly', var(--reader-font, serif);
+  }
+}
+
+#lavar {
+  background-color: blue;
+}
+
+#consertar {
+  background-color: green;
+}
+
+@media (min-width: 1024px) {
+  #menu-modes {
+    grid-template-columns: repeat(3, 90px);
+    grid-auto-rows: 90px;
+    gap: 20px;
+  }
+  #menu-modes img {
+    width: 90px;
+    height: 90px;
+  }
+  #mode-buttons img {
+    width: 47px;
+    height: 47px;
   }
 }
 

--- a/js/main.js
+++ b/js/main.js
@@ -440,7 +440,6 @@ function pauseGame(noPenalty = false) {
   bloqueado = true;
   const texto = document.getElementById('texto-exibicao');
   if (texto) {
-    texto.style.transition = 'opacity 500ms linear';
     texto.style.opacity = '0';
   }
   const input = document.getElementById('pt');
@@ -468,7 +467,6 @@ function resumeGame() {
   }
   const texto = document.getElementById('texto-exibicao');
   if (texto) {
-    texto.style.transition = 'opacity 500ms linear';
     texto.style.opacity = '1';
   }
   const input = document.getElementById('pt');
@@ -498,7 +496,6 @@ function triggerDownPlay() {
   if (input) input.disabled = true;
   const texto = document.getElementById('texto-exibicao');
   if (texto) {
-    texto.style.transition = 'opacity 2000ms linear';
     texto.style.opacity = '0';
   }
   const audio = new Audio('gamesounds/down.wav');
@@ -552,21 +549,16 @@ function reportLastError() {
 function updateLevelIcon() {
   const icon = document.getElementById('nivel-indicador');
   if (icon) {
-    icon.style.transition = 'opacity 500ms linear';
-    icon.style.opacity = '0';
-    setTimeout(() => {
-      icon.src = `selos_niveis/level%20${pastaAtual}.png`;
-      icon.style.opacity = '1';
-    }, 500);
+    icon.src = `selos_niveis/level%20${pastaAtual}.png`;
+    icon.style.opacity = '1';
   }
   localStorage.setItem('pastaAtual', pastaAtual);
 }
 
-function unlockMode(mode, duration = 1000) {
+function unlockMode(mode) {
   unlockedModes[mode] = true;
   localStorage.setItem('unlockedModes', JSON.stringify(unlockedModes));
   document.querySelectorAll(`#menu-modes img[data-mode="${mode}"], #mode-buttons img[data-mode="${mode}"]`).forEach(img => {
-    img.style.transition = `opacity ${duration}ms linear`;
     img.style.opacity = '1';
   });
 }
@@ -577,7 +569,7 @@ function updateModeIcons() {
     if (unlockedModes[mode]) {
       img.style.opacity = '1';
     } else {
-      img.style.opacity = '0.3';
+      img.style.opacity = '0.5';
     }
   });
   checkForMenuLevelUp();
@@ -596,8 +588,7 @@ function performMenuLevelUp() {
   const icons = document.querySelectorAll('#menu-modes img, #mode-buttons img');
   icons.forEach(img => {
     const modo = parseInt(img.dataset.mode, 10);
-    img.style.transition = 'opacity 500ms linear';
-    img.style.opacity = modo === 1 ? '1' : '0.3';
+    img.style.opacity = modo === 1 ? '1' : '0.5';
   });
   setTimeout(() => {
     pastaAtual++;
@@ -646,8 +637,7 @@ function menuLevelUpSequence() {
   const menu = document.getElementById('menu');
   const icons = menu.querySelectorAll('#menu-modes img');
   icons.forEach(img => {
-    img.style.transition = 'opacity 1ms linear';
-    img.style.opacity = '0.3';
+    img.style.opacity = '0.5';
   });
   const audio = document.getElementById('somNivelDesbloqueado');
   if (audio) { audio.currentTime = 0; audio.play(); }
@@ -655,30 +645,20 @@ function menuLevelUpSequence() {
   const msg = document.createElement('div');
   msg.id = 'next-level-msg';
   msg.textContent = 'diga next level para avançar';
-  msg.style.display = 'none';
   menu.appendChild(msg);
 
-  let idx = 0;
-  const interval = setInterval(() => {
-    if (idx < icons.length) {
-      icons[idx].style.opacity = '1';
-      idx++;
-    } else {
-      clearInterval(interval);
-      msg.style.display = 'block';
-      setTimeout(() => { msg.style.opacity = '1'; }, 10);
-      awaitingNextLevel = true;
-      nextLevelCallback = () => {
-        msg.remove();
-        performMenuLevelUp();
-      };
-      if (reconhecimento) {
-        reconhecimentoAtivo = true;
-        reconhecimento.lang = 'en-US';
-        reconhecimento.start();
-      }
-    }
-  }, 500);
+  icons.forEach(img => { img.style.opacity = '1'; });
+  msg.style.display = 'block';
+  awaitingNextLevel = true;
+  nextLevelCallback = () => {
+    msg.remove();
+    performMenuLevelUp();
+  };
+  if (reconhecimento) {
+    reconhecimentoAtivo = true;
+    reconhecimento.lang = 'en-US';
+    reconhecimento.start();
+  }
 }
 
 let transitioning = false;
@@ -767,19 +747,7 @@ function resetIntroProgress() {
   filled.style.backgroundColor = calcularCor(0);
 }
 
-function startTryAgainAnimation() {
-  const msg = document.getElementById('nivel-mensagem');
-  if (!msg) return;
-  if (tryAgainColorInterval) clearInterval(tryAgainColorInterval);
-  const duration = 30000;
-  const maxPoints = selectedMode === 6 ? MODE6_THRESHOLD : 25000;
-  const begin = Date.now();
-  tryAgainColorInterval = setInterval(() => {
-    const elapsed = (Date.now() - begin) % duration;
-    const pts = (elapsed / duration) * maxPoints;
-    msg.style.color = calcularCor(pts);
-  }, 50);
-}
+function startTryAgainAnimation() {}
 
 function stopTryAgainAnimation() {
   if (tryAgainColorInterval) clearInterval(tryAgainColorInterval);
@@ -865,103 +833,15 @@ function startGame(modo) {
 }
 
 function showMode1Intro(callback) {
-  const overlay = document.getElementById('intro-overlay');
-  const audio = document.getElementById('somModo1Intro');
-  const img = document.getElementById('intro-image');
-  atualizarBarraProgresso();
-  img.style.animation = 'none';
-  img.style.transition = 'none';
-  img.style.opacity = '1';
-  img.style.transform = 'scale(0.8)';
-  void img.offsetWidth;
-  img.style.transition = 'transform 10000ms linear';
-  overlay.style.display = 'flex';
-  startIntroProgress(10000);
-  audio.currentTime = 0;
-  audio.play();
-  img.style.transform = 'scale(1)';
-  setTimeout(() => {
-    img.style.transition = 'opacity 2000ms linear';
-    img.style.opacity = '0';
-  }, 8000);
-  setTimeout(() => {
-    overlay.style.display = 'none';
-    img.style.transition = 'none';
-    img.style.opacity = '1';
-    img.style.transform = 'scale(1)';
-    resetIntroProgress();
-    callback();
-  }, 10000);
+  callback();
 }
 
 function showModeIntro(info, callback) {
-  const overlay = document.getElementById('intro-overlay');
-  const img = document.getElementById('intro-image');
-  const audio = document.getElementById(info.audio);
-  atualizarBarraProgresso();
-  img.src = info.img;
-  img.style.animation = 'none';
-  img.style.transition = 'none';
-  img.style.opacity = '1';
-  img.style.transform = 'scale(0.8)';
-  void img.offsetWidth;
-  img.style.transition = `transform ${info.duration}ms linear`;
-  overlay.style.display = 'flex';
-  startIntroProgress(info.duration);
-  if (audio) {
-    audio.currentTime = 0;
-    audio.play();
-  }
-  img.style.transform = 'scale(1)';
-  setTimeout(() => {
-    img.style.transition = 'opacity 2000ms linear';
-    img.style.opacity = '0';
-  }, info.duration - 2000);
-  setTimeout(() => {
-    overlay.style.display = 'none';
-    img.style.transition = 'none';
-    img.style.opacity = '1';
-    img.style.transform = 'scale(1)';
-    resetIntroProgress();
-    callback();
-  }, info.duration);
+  callback();
 }
 
 function showModeTransition(info, callback) {
-  const overlay = document.getElementById('intro-overlay');
-  const img = document.getElementById('intro-image');
-  const audio = document.getElementById(info.audio);
-  atualizarBarraProgresso();
-  if (reconhecimento) {
-    reconhecimentoAtivo = false;
-    reconhecimento.stop();
-  }
-  img.src = info.img;
-  img.style.animation = 'none';
-  img.style.transition = 'none';
-  img.style.opacity = '1';
-  img.style.transform = 'scale(0.8)';
-  void img.offsetWidth;
-  img.style.transition = `transform ${info.duration}ms linear`;
-  overlay.style.display = 'flex';
-  startIntroProgress(info.duration);
-  if (audio) {
-    audio.currentTime = 0;
-    audio.play();
-  }
-  img.style.transform = 'scale(1)';
-  setTimeout(() => {
-    img.style.transition = 'opacity 2000ms linear';
-    img.style.opacity = '0';
-  }, info.duration - 2000);
-  setTimeout(() => {
-    overlay.style.display = 'none';
-    img.style.transition = 'none';
-    img.style.opacity = '1';
-    img.style.transform = 'scale(1)';
-    resetIntroProgress();
-    callback();
-  }, info.duration);
+  callback();
 }
 
 function showLevelUp(callback) {
@@ -1119,28 +999,7 @@ function toggleEn() {
 }
 
 function showShortModeIntro(modo, callback) {
-  const overlay = document.getElementById('intro-overlay');
-  const img = document.getElementById('intro-image');
-  const audio = document.getElementById('somWoosh');
-  img.src = modeImages[modo];
-  img.style.animation = 'none';
-  img.style.transition = 'none';
-  img.style.opacity = '1';
-  img.style.width = '200px';
-  img.style.height = '200px';
-  void img.offsetWidth;
-  img.style.transition = 'width 3000ms linear, height 3000ms linear';
-  overlay.style.display = 'flex';
-  if (audio) { audio.currentTime = 0; audio.play(); }
-  img.style.width = '350px';
-  img.style.height = '350px';
-  setTimeout(() => {
-    overlay.style.display = 'none';
-    img.style.transition = 'none';
-    img.style.width = '';
-    img.style.height = '';
-    callback();
-  }, 3000);
+  callback();
 }
 
 function falarFrase() {
@@ -1227,10 +1086,8 @@ function mostrarFrase() {
 function flashSuccess(callback) {
   const texto = document.getElementById('texto-exibicao');
   const color = calcularCor(points);
-  texto.style.transition = 'color 500ms linear';
   texto.style.color = color;
   setTimeout(() => {
-    texto.style.transition = 'color 500ms linear';
     texto.style.color = '#333';
     setTimeout(() => {
       document.getElementById('resultado').textContent = '';
@@ -1243,10 +1100,8 @@ function flashError(expected, callback) {
   const texto = document.getElementById('texto-exibicao');
   const previous = texto.textContent;
   texto.textContent = expected;
-  texto.style.transition = 'color 500ms linear';
   texto.style.color = 'red';
   setTimeout(() => {
-    texto.style.transition = 'color 500ms linear';
     texto.style.color = '#333';
     setTimeout(() => {
       texto.textContent = previous;
@@ -1546,7 +1401,7 @@ function startTutorial() {
   tutorialInProgress = true;
   localStorage.setItem('tutorialDone', 'true');
   const welcome = document.getElementById('somWelcome');
-  if (welcome) setTimeout(() => { welcome.currentTime = 0; welcome.play(); }, 1);
+  if (welcome) { welcome.currentTime = 0; welcome.play(); }
 
   const tutorialLogo = document.getElementById('tutorial-logo');
   const logoTop = document.getElementById('logo-top');
@@ -1557,44 +1412,18 @@ function startTutorial() {
   if (levelIcon) levelIcon.style.display = 'none';
   if (menuLogo) menuLogo.style.display = 'none';
   if (tutorialLogo) {
-    tutorialLogo.style.display = 'block';
-    tutorialLogo.style.width = '20%';
-    setTimeout(() => { tutorialLogo.style.display = 'none'; }, 750);
+    tutorialLogo.style.display = 'none';
   }
 
-  menuIcons.forEach(img => { img.style.opacity = '0'; });
-
-  setTimeout(() => {
-    menuIcons.forEach(img => {
-      img.style.transition = 'opacity 2000ms linear';
-      img.style.opacity = '0.3';
-    });
-  }, 4000);
-
-  setTimeout(() => {
-    const seq = [1, 2, 3, 4, 5, 6].map(n => document.querySelector(`#menu-modes img[data-mode="${n}"]`));
-    seq.forEach((img, idx) => {
-      setTimeout(() => {
-        if (!img) return;
-        img.style.transition = 'opacity 200ms linear';
-        img.style.opacity = '0.99';
-        setTimeout(() => {
-          img.style.transition = 'opacity 200ms linear';
-          img.style.opacity = '0.3';
-        }, 200);
-      }, idx * 450);
-    });
-  }, 7000);
+  menuIcons.forEach(img => { img.style.opacity = '0.5'; });
 
   const mode1 = document.querySelector('#menu-modes img[data-mode="1"]');
 
-  setTimeout(() => { if (levelIcon) levelIcon.style.display = 'block'; }, 11420);
-  setTimeout(() => {
-    if (logoTop) logoTop.style.display = 'block';
-    if (menuLogo) menuLogo.style.display = 'block';
-    if (mode1) unlockMode(1, 1000);
-    tutorialInProgress = false;
-  }, 11421);
+  if (levelIcon) levelIcon.style.display = 'block';
+  if (logoTop) logoTop.style.display = 'block';
+  if (menuLogo) menuLogo.style.display = 'block';
+  if (mode1) unlockMode(1);
+  tutorialInProgress = false;
 }
 
 
@@ -1651,6 +1480,7 @@ async function initGame() {
         if (lock) { lock.currentTime = 0; lock.play(); }
         return;
       }
+      img.style.opacity = '1';
       startGame(modo);
     });
   });

--- a/js/play.js
+++ b/js/play.js
@@ -99,7 +99,6 @@ function createStatCircle(perc, label, iconSrc, extraText) {
 
 document.addEventListener('DOMContentLoaded', () => {
   const container = document.getElementById('play-content');
-  container.style.transition = 'opacity 0.2s';
   const buttons = document.querySelectorAll('#mode-buttons img');
   const clickSound = new Audio('gamesounds/mododesbloqueado.mp3');
   const statsData = JSON.parse(localStorage.getItem('modeStats') || '{}');
@@ -196,27 +195,23 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   function render(mode) {
-    container.style.opacity = 0;
-    setTimeout(() => {
-      container.innerHTML = '';
-      if (mode === 1) {
-        const { accPerc, timePerc, notReportPerc } = calcGeneralStats();
-        container.appendChild(createStatCircle(accPerc, 'Precisão', 'selos%20modos%20de%20jogo/precisao.png'));
-        container.appendChild(createStatCircle(timePerc, 'Tempo', 'selos%20modos%20de%20jogo/velocidade.png'));
-        container.appendChild(createStatCircle(notReportPerc, 'Report', 'selos%20modos%20de%20jogo/reports.png'));
-      } else {
-        const { accPerc, timePerc, notReportPerc } = calcModeStats(mode);
-        container.appendChild(createStatCircle(accPerc, 'Precisão', 'selos%20modos%20de%20jogo/precisao.png'));
-        container.appendChild(createStatCircle(timePerc, 'Tempo', 'selos%20modos%20de%20jogo/velocidade.png'));
-        container.appendChild(createStatCircle(notReportPerc, 'Report', 'selos%20modos%20de%20jogo/reports.png'));
-      }
-      container.style.opacity = 1;
-    }, 150);
+    container.innerHTML = '';
+    if (mode === 1) {
+      const { accPerc, timePerc, notReportPerc } = calcGeneralStats();
+      container.appendChild(createStatCircle(accPerc, 'Precisão', 'selos%20modos%20de%20jogo/precisao.png'));
+      container.appendChild(createStatCircle(timePerc, 'Tempo', 'selos%20modos%20de%20jogo/velocidade.png'));
+      container.appendChild(createStatCircle(notReportPerc, 'Report', 'selos%20modos%20de%20jogo/reports.png'));
+    } else {
+      const { accPerc, timePerc, notReportPerc } = calcModeStats(mode);
+      container.appendChild(createStatCircle(accPerc, 'Precisão', 'selos%20modos%20de%20jogo/precisao.png'));
+      container.appendChild(createStatCircle(timePerc, 'Tempo', 'selos%20modos%20de%20jogo/velocidade.png'));
+      container.appendChild(createStatCircle(notReportPerc, 'Report', 'selos%20modos%20de%20jogo/reports.png'));
+    }
   }
 
   function selectMode(mode) {
     buttons.forEach(img => {
-      img.style.opacity = img.dataset.mode == mode ? '1' : '0.3';
+      img.style.opacity = img.dataset.mode == mode ? '1' : '0.5';
     });
     render(mode);
   }
@@ -234,10 +229,5 @@ document.addEventListener('DOMContentLoaded', () => {
   const seq = localStorage.getItem('statsSequence');
   if (seq === 'true') {
     localStorage.removeItem('statsSequence');
-    let delay = 3000;
-    [2, 3, 4, 5, 6].forEach(mode => {
-      setTimeout(() => selectMode(mode), delay);
-      delay += 1500;
-    });
   }
 });

--- a/js/versus.js
+++ b/js/versus.js
@@ -65,7 +65,11 @@ document.addEventListener('DOMContentLoaded', () => {
         const div = document.createElement('div');
         div.className = 'bot-item';
         div.innerHTML = `<img src="users/${bot.file}" alt="${bot.name}"><div>${bot.name}</div>`;
-        div.addEventListener('click', () => showModes(bot));
+        div.addEventListener('click', () => {
+          const img = div.querySelector('img');
+          if (img) img.style.opacity = '1';
+          showModes(bot);
+        });
         list.appendChild(div);
       });
     });
@@ -120,7 +124,10 @@ document.addEventListener('DOMContentLoaded', () => {
       img.src = `selos%20modos%20de%20jogo/modo${i}.png`;
       img.alt = `Modo ${i}`;
       img.dataset.mode = i;
-      img.addEventListener('click', () => startVersus(bot, i));
+      img.addEventListener('click', () => {
+        img.style.opacity = '1';
+        startVersus(bot, i);
+      });
       modeList.appendChild(img);
     }
     modeList.style.display = 'grid';
@@ -202,18 +209,14 @@ document.addEventListener('DOMContentLoaded', () => {
       speechSynthesis.cancel();
       speechSynthesis.speak(utter);
     } else {
-      setTimeout(() => {
-        fraseEl.style.transition = 'opacity 500ms, font-size 1000ms';
-        fraseEl.style.opacity = 1;
-        fraseEl.style.fontSize = '45px';
-      }, 50);
+      fraseEl.style.opacity = 1;
+      fraseEl.style.fontSize = '45px';
     }
     inicioFrase = Date.now();
     fraseIndex++;
   }
 
   function flashColor(cor) {
-    fraseEl.style.transition = 'color 500ms';
     fraseEl.style.color = cor;
     setTimeout(() => {
       fraseEl.style.color = '#fff';
@@ -282,12 +285,9 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   function setBar(fill, perc) {
-    fill.style.opacity = 0;
-    setTimeout(() => {
-      fill.style.width = (perc * 2) + 'px';
-      fill.style.backgroundColor = colorFromPercent(perc);
-      fill.style.opacity = 1;
-    }, 200);
+    fill.style.width = (perc * 2) + 'px';
+    fill.style.backgroundColor = colorFromPercent(perc);
+    fill.style.opacity = 1;
   }
 
   function updateBars() {
@@ -316,7 +316,6 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   function encerrar() {
-    fraseEl.style.transition = 'opacity 0.5s';
     fraseEl.style.opacity = 0;
     modoAtual = 0;
     if (reconhecimento) try { reconhecimento.stop(); } catch (err) {}


### PR DESCRIPTION
## Summary
- disable all animations and transitions
- set items to 50% opacity by default and full opacity on interaction
- color lavar and consertar buttons and shrink items on desktop

## Testing
- `npm test` *(fails: Error: no test specified)*
- `node --check js/main.js`
- `node --check js/play.js`
- `node --check js/versus.js`


------
https://chatgpt.com/codex/tasks/task_e_68a9deee353c83258119d2965e5b2b3c