### PR TITLE
feat: smart song buffering and tap-based item options

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -187,6 +187,20 @@ body.dark-mode #clock {
   width: 0%;
   background-color: #ff0000;
   border-radius: 10px;
+  position: absolute;
+  top: 0;
+  left: 0;
+}
+
+#barra-buffer {
+  height: 100%;
+  width: 0%;
+  background-color: #ff0000;
+  border-radius: 10px;
+  position: absolute;
+  top: 0;
+  left: 0;
+  opacity: 0.5;
 }
 
 #mode-stats,
@@ -691,11 +705,28 @@ body.play-page #play-content {
 }
 
 #lavar {
-  background-color: blue;
+  background: linear-gradient(to bottom, #4da3ff, #0066cc);
+  color: #fff;
+  border: none;
+  padding: 5px 10px;
 }
 
 #consertar {
-  background-color: green;
+  background: linear-gradient(to bottom, #ffa64d, #e67300);
+  color: #fff;
+  border: none;
+  padding: 5px 10px;
+}
+
+.item-options {
+  position: absolute;
+  display: flex;
+  gap: 10px;
+  z-index: 1000;
+}
+
+.item.verificado {
+  outline: 2px solid #40e0d0;
 }
 
 @media (min-width: 1024px) {

--- a/index.html
+++ b/index.html
@@ -46,6 +46,7 @@
     </div>
     <div id="texto-exibicao"></div>
     <div id="barra-progresso">
+      <div id="barra-buffer"></div>
       <div id="barra-preenchida"></div>
     </div>
     <div id="pt-container">
@@ -96,5 +97,7 @@
 
   <script src="js/disableScroll.js"></script>
   <script src="js/main.js"></script>
+  <script src="js/songs.js"></script>
+  <script src="js/items.js"></script>
 </body>
 </html>

--- a/js/items.js
+++ b/js/items.js
@@ -1,0 +1,36 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const items = document.querySelectorAll('.item');
+  items.forEach(item => {
+    let taps = [];
+    item.addEventListener('click', () => {
+      const now = Date.now();
+      taps = taps.filter(t => now - t < 5000);
+      taps.push(now);
+      if (taps.length >= 4) {
+        showOptions(item);
+        taps = [];
+      } else {
+        item.classList.add('verificado');
+      }
+    });
+  });
+});
+
+function showOptions(target) {
+  const existing = document.querySelector('.item-options');
+  if (existing) existing.remove();
+  const box = document.createElement('div');
+  box.className = 'item-options';
+  const lavar = document.createElement('button');
+  lavar.id = 'lavar';
+  lavar.textContent = 'Lavar';
+  const consertar = document.createElement('button');
+  consertar.id = 'consertar';
+  consertar.textContent = 'Consertar';
+  box.appendChild(lavar);
+  box.appendChild(consertar);
+  document.body.appendChild(box);
+  const rect = target.getBoundingClientRect();
+  box.style.top = rect.bottom + 'px';
+  box.style.left = rect.left + 'px';
+}

--- a/js/songs.js
+++ b/js/songs.js
@@ -1,0 +1,115 @@
+(function() {
+  const CHUNK_SECONDS = 30;
+  const BITRATE = 128000; // bits per second
+  const CHUNK_BYTES = Math.floor(BITRATE / 8 * CHUNK_SECONDS);
+  const songs = [
+    'gamesounds/letsplay.mp3',
+    'gamesounds/letsplay2.mp3',
+    'gamesounds/mode1first.mp3',
+    'gamesounds/mode2first.mp3',
+    'gamesounds/mode3first.mp3',
+    'gamesounds/mode4first.mp3',
+    'gamesounds/mode5first.mp3',
+    'gamesounds/mode6first.mp3',
+    'gamesounds/nextlevel.mp3',
+    'gamesounds/success.mp3',
+    'gamesounds/error.mp3',
+    'gamesounds/welcome.mp3'
+  ];
+  const cache = {};
+  let current = null;
+
+  function setBufferWidth(percent) {
+    const buffer = document.getElementById('barra-buffer');
+    const playBar = document.getElementById('barra-preenchida');
+    if (!buffer || !playBar) return;
+    buffer.style.width = percent + '%';
+    buffer.style.backgroundColor = getComputedStyle(playBar).backgroundColor;
+  }
+
+  function storeFull(url, blob) {
+    const reader = new FileReader();
+    reader.onloadend = () => localStorage.setItem('song_' + url, reader.result);
+    reader.readAsDataURL(blob);
+  }
+
+  function preload(url) {
+    if (localStorage.getItem('song_' + url)) {
+      cache[url] = {
+        audio: new Audio(localStorage.getItem('song_' + url)),
+        loaded: true
+      };
+      return Promise.resolve();
+    }
+    return fetch(url, { headers: { Range: `bytes=0-${CHUNK_BYTES - 1}` } })
+      .then(r => r.arrayBuffer())
+      .then(buf => {
+        const blob = new Blob([buf]);
+        const audio = new Audio(URL.createObjectURL(blob));
+        cache[url] = {
+          audio,
+          firstChunk: buf,
+          loadedBytes: buf.byteLength,
+          loaded: false
+        };
+        audio.addEventListener('loadedmetadata', () => {
+          const percent = Math.min(CHUNK_SECONDS / audio.duration, 1) * 100;
+          setBufferWidth(percent);
+        });
+        const reader = new FileReader();
+        reader.onloadend = () => localStorage.setItem('song_' + url + '_part', reader.result);
+        reader.readAsDataURL(blob);
+      });
+  }
+
+  function play(url) {
+    const entry = cache[url];
+    if (!entry) return;
+    const audio = entry.audio;
+    current = entry;
+    audio.play();
+    audio.addEventListener('timeupdate', function onTime() {
+      if (!entry.loaded && audio.currentTime > CHUNK_SECONDS - 5) {
+        entry.loaded = true;
+        fetch(url, { headers: { Range: `bytes=${entry.loadedBytes}-` } })
+          .then(r => r.arrayBuffer())
+          .then(rest => {
+            const fullBlob = new Blob([entry.firstChunk, rest]);
+            const pos = audio.currentTime;
+            audio.src = URL.createObjectURL(fullBlob);
+            audio.currentTime = pos;
+            setBufferWidth(100);
+            storeFull(url, fullBlob);
+          });
+      }
+      if (audio.duration) {
+        const buffered = entry.loaded ? audio.duration : Math.min(CHUNK_SECONDS, audio.duration);
+        setBufferWidth(buffered / audio.duration * 100);
+      }
+    });
+  }
+
+  function fadeOut(audio) {
+    const step = audio.volume / 30;
+    const fade = setInterval(() => {
+      audio.volume = Math.max(0, audio.volume - step);
+      if (audio.volume <= 0) {
+        clearInterval(fade);
+        audio.pause();
+        audio.volume = 1;
+      }
+    }, 100);
+  }
+
+  function pause() {
+    if (current) {
+      fadeOut(current.audio);
+    }
+  }
+
+  window.SongPlayer = { play, pause };
+
+  document.addEventListener('DOMContentLoaded', () => {
+    songs.forEach(preload);
+  });
+})();


### PR DESCRIPTION
## Summary
- show buffered music on progress bar and preload first 30 seconds of songs
- add fade-out pause and cache loaded tracks in localStorage
- switch item selection to single tap with quadruple-tap options and gradient buttons

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68aa9ee40b2083259e0e2e7b89ae05b7