### PR TITLE
Skip intro and unlock mode 1 by default

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,6 +7,10 @@
   <link href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@400;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="css/style.css">
   <script>
+    const ilifeStatus = localStorage.getItem('ilifeDone');
+    if (ilifeStatus !== 'true') {
+      localStorage.setItem('ilifeDone', 'true');
+    }
     if (localStorage.getItem('ilifeDone') === 'true') {
       document.write('<style>#ilife-screen{display:none;}#menu{display:flex;}</style>');
     }

--- a/js/main.js
+++ b/js/main.js
@@ -254,7 +254,17 @@ function getTimeMetrics(len, mode) {
   return { perfect, worst };
 }
 let completedModes = JSON.parse(localStorage.getItem('completedModes') || '{}');
-let unlockedModes = JSON.parse(localStorage.getItem('unlockedModes') || '{}');
+let unlockedModes;
+try {
+  const storedUnlocked = localStorage.getItem('unlockedModes');
+  unlockedModes = storedUnlocked ? JSON.parse(storedUnlocked) : null;
+} catch (e) {
+  unlockedModes = null;
+}
+if (!unlockedModes || Object.keys(unlockedModes).length === 0) {
+  unlockedModes = { 1: true };
+  localStorage.setItem('unlockedModes', JSON.stringify(unlockedModes));
+}
 let modeIntroShown = JSON.parse(localStorage.getItem('modeIntroShown') || '{}');
 let points = parseInt(localStorage.getItem('points') || INITIAL_POINTS, 10);
 let premioBase = 4000;
@@ -271,6 +281,10 @@ let levelUpReady = false;
 let tutorialInProgress = false;
 let tutorialDone = localStorage.getItem('tutorialDone') === 'true';
 let ilifeDone = localStorage.getItem('ilifeDone') === 'true';
+if (!ilifeDone) {
+  localStorage.setItem('ilifeDone', 'true');
+  ilifeDone = true;
+}
 let ilifeActive = false;
 let sessionStart = null;
 const legacyStats = JSON.parse(localStorage.getItem('mode1Stats') || 'null');


### PR DESCRIPTION
## Summary
- skip the iLife presentation by default so the menu is shown immediately
- ensure mode 1 is unlocked when no previous progress exists so players can start right away

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e0cce9317083258f786a2aa27288ad