### PR TITLE
Fix mobile layout for game mode icons

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -117,6 +117,9 @@ body.dark-mode #clock {
   grid-template-columns: repeat(3, 227px);
   grid-auto-rows: 227px;
   gap: 50px;
+  justify-content: center;
+  justify-items: center;
+  align-items: center;
 }
 
 #menu-modes img {
@@ -379,13 +382,14 @@ body.play-page #play-content {
   }
 
   #menu-modes {
-    grid-template-columns: repeat(3, 1fr);
+    grid-template-columns: repeat(2, 100px);
+    grid-auto-rows: 100px;
     gap: 20px;
   }
 
   #menu-modes img {
-    width: 36.4vw;
-    height: 36.4vw;
+    width: 100px;
+    height: 100px;
   }
 }
 


### PR DESCRIPTION
## Summary
- center the game mode grid and align items within the menu
- update the mobile breakpoint to use a 2x3 grid with 100px icons

## Testing
- no automated tests were run

------
https://chatgpt.com/codex/tasks/task_e_68e0cf058178832591284b1491c3e9db