### PR TITLE
Adjust mobile play layout

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -391,6 +391,36 @@ body.play-page #play-content {
     width: 100px;
     height: 100px;
   }
+
+  #barra-progresso {
+    background: rgba(0, 0, 0, 0.1);
+  }
+
+  body.play-page #mode-buttons {
+    position: static;
+    margin: 50px auto 0;
+    display: grid;
+    grid-template-columns: repeat(3, 75px);
+    grid-template-rows: repeat(2, 75px);
+    gap: 20px;
+    justify-content: center;
+    justify-items: center;
+    transform: none;
+    width: 100%;
+  }
+
+  body.play-page #mode-buttons img,
+  #mode-buttons img {
+    width: 75px;
+    height: 75px;
+  }
+
+  #nivel-indicador {
+    left: 50%;
+    transform: translateX(-50%);
+    width: calc(68px * 1.2);
+    height: calc(68px * 1.2);
+  }
 }
 
 


### PR DESCRIPTION
## Summary
- set the mobile progress bar background to a translucent black and keep it aligned with the viewport
- center and enlarge the current level indicator for small screens
- arrange the six mode icons into a centered 3x2 grid positioned below the progress bar on mobile

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e0d23519e48325aba3adcb9b1dbed1