### PR TITLE
Adjust progress bar spacing above mode icons

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -182,7 +182,14 @@ body.dark-mode #clock {
   background: #ddd;
   border-radius: 10px;
   overflow: hidden;
-  position: relative;
+  position: fixed;
+  bottom: calc(160px + 117px + 50px);
+  left: 50%;
+  transform: translateX(-50%);
+}
+
+body.play-page #barra-progresso {
+  bottom: calc(95px + 75px + 50px);
 }
 
 #barra-preenchida {
@@ -209,8 +216,7 @@ body.dark-mode #clock {
 }
 
 #mode-stats,
-#texto-exibicao,
-#barra-progresso {
+#texto-exibicao {
   transform: translateY(-170px);
 }
 
@@ -410,6 +416,9 @@ body.play-page #play-content {
 
   #barra-progresso {
     background: rgba(255, 255, 255, 0.2);
+    position: static;
+    transform: none;
+    margin: 0 auto 50px;
   }
 
   #barra-buffer {
@@ -731,6 +740,7 @@ body.play-page #play-content {
   height: 10px;
   margin: 0;
   background: #333;
+  transform: none;
 }
 
 #versus-game #barra-preenchida {


### PR DESCRIPTION
## Summary
- anchor the main progress bar 50px above the six mode icons on desktop layouts
- tune the play page offset and mobile breakpoint styles to preserve the new spacing
- keep the versus view progress bar pinned to the bottom without horizontal translation

## Testing
- npm start

------
https://chatgpt.com/codex/tasks/task_e_68e11a674d6083259f11c9e6352c1b23